### PR TITLE
Allow specified extension file in any location

### DIFF
--- a/internal/cmd/pgxman/build.go
+++ b/internal/cmd/pgxman/build.go
@@ -11,6 +11,7 @@ import (
 
 var (
 	flagBuildSet       map[string]string
+	flagExtensionFile  string
 	flagBuildNoCache   bool
 	flagBuildCacheFrom []string
 	flagBuildCacheTo   []string
@@ -23,6 +24,7 @@ func newBuildCmd() *cobra.Command {
 		RunE:  runBuild,
 	}
 
+	cmd.PersistentFlags().StringVarP(&flagExtensionFile, "file", "f", "extension.yaml", "Path to the extension manifest file")
 	cmd.PersistentFlags().StringToStringVarP(&flagBuildSet, "set", "s", nil, "Override values in the extension.yaml file in the format of --set KEY=VALUE, e.g. --set version=1.0.0 --set arch=[amd64,arm64] --set pgVersions=[10,11,12]")
 	cmd.PersistentFlags().BoolVar(&flagBuildNoCache, "no-cache", false, "Do not use cache when building the image. The value is passed to docker buildx build --no-cache.")
 	cmd.PersistentFlags().StringArrayVar(&flagBuildCacheFrom, "cache-from", nil, "External cache sources. The value is passed to docker buildx build --cache-from.")
@@ -32,14 +34,18 @@ func newBuildCmd() *cobra.Command {
 }
 
 func runBuild(c *cobra.Command, args []string) error {
-	pwd, err := os.Getwd()
+	extFile, err := filepath.Abs(flagExtensionFile)
 	if err != nil {
 		return err
 	}
 
 	overrides := cmd.ParseMapFlag(flagBuildSet)
+	ext, err := pgxman.ReadExtension(extFile, overrides)
+	if err != nil {
+		return err
+	}
 
-	ext, err := pgxman.ReadExtension(filepath.Join(pwd, "extension.yaml"), overrides)
+	pwd, err := os.Getwd()
 	if err != nil {
 		return err
 	}


### PR DESCRIPTION
Allow specified extension file in any location. This helps with reorganizing https://github.com/pgxman/buildkit  folder structure into:

```
- buildkit
  - pgvector
  - psql-http
  - ...
- script
```