### PR TITLE
Make builder base image base on ubuntu:22.04

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -15,7 +15,7 @@ RUN --mount=target=. \
     -ldflags "-s -w -X github.com/pgxman/pgxman/pgxm.Version=$BUILD_VERSION" \
     ./cmd/...
 
-FROM postgres:15-bookworm
+FROM ubuntu:22.04
 
 ARG DEBIAN_FRONTEND=noninteractive
 


### PR DESCRIPTION
Make builder base image base on ubuntu:22.04. Basing on postgres:15-bookworm can have the following errors:

```
2.531 The following packages have unmet dependencies:
2.584  postgresql-15-pgxman-hydra-columnar : Depends: libzstd1 (>= 1.5.2) but 1.4.8+dfsg-3build1 is to be installed
```

Although ubuntu:22.04 bases on bookworm, there are differences in available package versions. We are making the builder image bases on the ubuntu:22.04 which potentially has older versions of the debian pakcages so built extensions work for both ubuntu:22.04 & bookworm.