### PR TITLE
Apply docker/metadata-action bake file tags in CI

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -45,6 +45,9 @@ jobs:
     name: E2Etest
     needs: [build, test, vet]
     runs-on: ubuntu-latest
+    env:
+      DEBIAN_BOOKWORM_IMAGE: localhost:5000/pgxman/builder/debian/bookworm:dev
+      UBUNTU_JAMMY_IMAGE: localhost:5000/pgxman/builder/ubuntu/jammy:dev
     services:
       registry:
         image: registry:2
@@ -62,9 +65,6 @@ jobs:
           driver-opts: network=host
       - name: Build and push to local registry
         uses: docker/bake-action@v3
-        env:
-          DEBIAN_BOOKWORM_REPO: localhost:5000/pgxman/builder/debian/bookworm
-          UBUNTU_JAMMY_REPO: localhost:5000/pgxman/builder/ubuntu/jammy
         with:
           push: true
           pull: true
@@ -76,9 +76,11 @@ jobs:
             *.platform=linux/amd64
             *.cache-from=type=gha
             *.cache-to=type=gha,mode=max
+            debian-bookworm.tags=${{ env.DEBIAN_BOOKWORM_IMAGE }}
+            ubuntu-jammy.tags=${{ env.UBUNTU_JAMMY_IMAGE }}
       - name: Run e2etest
         run: |
-          E2ETEST_DEBIAN_BOOKWORM_IMAGE=localhost:5000/pgxman/builder/debian/bookworm:dev E2ETEST_UBUNTU_JAMMY_IMAGE=localhost:5000/pgxman/builder/ubuntu/jammy:dev make e2etest
+          make e2etest
   docker:
     name: Docker
     needs: [e2etest]

--- a/Makefile
+++ b/Makefile
@@ -21,8 +21,8 @@ GO_TEST_FLAGS ?=
 test:
 	go test $$(go list ./... | grep -v e2etest) $(GO_TEST_FLAGS) -count=1 -race -v
 
-E2ETEST_DEBIAN_BOOKWORM_IMAGE ?= ghcr.io/pgxman/builder/debian/bookworm:main
-E2ETEST_UBUNTU_JAMMY_IMAGE ?= ghcr.io/pgxman/builder/ubuntu/jammy:main
+DEBIAN_BOOKWORM_IMAGE ?= ghcr.io/pgxman/builder/debian/bookworm:main
+UBUNTU_JAMMY_IMAGE ?= ghcr.io/pgxman/builder/ubuntu/jammy:main
 .PHONY: e2etest
 e2etest:
 	GOOS=linux GOARCH=$$(go env GOARCH) go build -o $(BIN_DIR)/pgxman_linux_$$(go env GOARCH) ./cmd/pgxman
@@ -31,8 +31,8 @@ e2etest:
 		-count=1 -race \
 		-v \
 		-e2e \
-		-debian-bookworm-image $(E2ETEST_DEBIAN_BOOKWORM_IMAGE) \
-		-ubuntu-jammy-image $(E2ETEST_UBUNTU_JAMMY_IMAGE) \
+		-debian-bookworm-image $(DEBIAN_BOOKWORM_IMAGE) \
+		-ubuntu-jammy-image $(UBUNTU_JAMMY_IMAGE) \
 		-pgxman-bin $(BIN_DIR)/pgxman_linux_$$(go env GOARCH)
 
 .PHONY: vet
@@ -45,10 +45,14 @@ vet:
 		golangci/golangci-lint:v1.53 \
 		golangci-lint run --timeout 5m -v
 
-REPO ?= ghcr.io/pgxman/builder
 .PHONY: docker_build
 docker_build:
-	docker buildx bake -f $(PWD)/docker/docker-bake.hcl --pull --load
+	docker buildx bake \
+		-f $(PWD)/docker/docker-bake.hcl \
+		--set debian-bookworm.tags=$(DEBIAN_BOOKWORM_IMAGE) \
+		--set ubuntu-jammy.tags=$(UBUNTU_JAMMY_IMAGE) \
+		--pull \
+		--load
 
 .PHONY: docker_push
 docker_push:

--- a/docker/docker-bake.hcl
+++ b/docker/docker-bake.hcl
@@ -1,17 +1,5 @@
 
-variable "BASE_REPO" {
-    default = "ghcr.io/pgxman/builder"
-}
-
-variable "DEBIAN_BOOKWORM_REPO" {
-    default = "${BASE_REPO}/debian/bookworm"
-}
-
-variable "UBUNTU_JAMMY_REPO" {
-    default = "${BASE_REPO}/ubuntu/jammy"
-}
-
-variable "TAG" {
+variable "BUILD_VERSION" {
     default = "dev"
 }
 
@@ -28,7 +16,6 @@ target "debian-bookworm" {
     }
 
     dockerfile = "docker/Dockerfile.debian"
-    tags = ["${DEBIAN_BOOKWORM_REPO}:${TAG}"]
 }
 
 target "ubuntu-jammy" {
@@ -40,7 +27,6 @@ target "ubuntu-jammy" {
     }
 
     dockerfile = "docker/Dockerfile.debian"
-    tags = ["${UBUNTU_JAMMY_REPO}:${TAG}"]
 }
 
 target "pgxman" {
@@ -48,7 +34,7 @@ target "pgxman" {
     target = "gobuild"
 
     args = {
-        BUILD_VERSION = "${TAG}"
+        BUILD_VERSION = "${BUILD_VERSION}"
     }
 }
 


### PR DESCRIPTION
The combined tags do not reflect the bake file from docker/metadata-action: https://github.com/pgxman/pgxman/actions/runs/5943908711/job/16120264053#step:8:168