### PR TITLE
Update apt repo with support of multiple prefix & codename

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -56,7 +56,12 @@ docker_build:
 
 .PHONY: docker_push
 docker_push:
-	docker buildx bake -f $(PWD)/docker/docker-bake.hcl --pull --push
+	docker buildx bake \
+		-f $(PWD)/docker/docker-bake.hcl \
+		--set debian-bookworm.tags=$(DEBIAN_BOOKWORM_IMAGE) \
+		--set ubuntu-jammy.tags=$(UBUNTU_JAMMY_IMAGE) \
+		--pull \
+		--push
 
 .PHONY: goreleaser
 goreleaser:

--- a/internal/plugin/debian/installer.go
+++ b/internal/plugin/debian/installer.go
@@ -97,6 +97,7 @@ func runAptInstall(ctx context.Context, debPkgs []string, aptRepos []pgxman.AptR
 		logger.Debug("Running apt install", "package", pkg)
 
 		cmd := exec.CommandContext(ctx, "apt", "install", "-y", "--no-install-recommends", pkg)
+		cmd.Env = append(os.Environ(), "DEBIAN_FRONTEND=noninteractive")
 		cmd.Stdout = os.Stdout
 		cmd.Stderr = os.Stderr
 


### PR DESCRIPTION
After https://github.com/pgxman/buildkit/pull/16, we separate prefix & codename for a debian like distro.