### PR TITLE
Support options when installing an extension

### DIFF
--- a/installer.go
+++ b/installer.go
@@ -40,9 +40,10 @@ func (exts PGXManfile) Validate() error {
 }
 
 type InstallExtension struct {
-	Name    string `json:"name,omitempty"`
-	Version string `json:"version,omitempty"`
-	Path    string `json:"path,omitempty"`
+	Name    string   `json:"name,omitempty"`
+	Version string   `json:"version,omitempty"`
+	Path    string   `json:"path,omitempty"`
+	Options []string `json:"options,omitempty"`
 }
 
 func (e InstallExtension) Validate() error {

--- a/internal/plugin/debian/packager.go
+++ b/internal/plugin/debian/packager.go
@@ -183,15 +183,25 @@ func (p *DebianPackager) installBuildDependencies(ctx context.Context, ext pgxma
 		deps = builder.BuildDependencies
 	}
 
-	var depsToInstall []string
+	var depsToInstall []installDebPkg
 	for _, dep := range deps {
 		if strings.Contains(dep, extensionDepPrefix) {
 			dep = strings.TrimPrefix(dep, extensionDepPrefix)
 			for _, ver := range ext.PGVersions {
-				depsToInstall = append(depsToInstall, extensionDebPkg(string(ver), dep))
+				depsToInstall = append(
+					depsToInstall,
+					installDebPkg{
+						Pkg: extensionDebPkg(string(ver), dep),
+					},
+				)
 			}
 		} else {
-			depsToInstall = append(depsToInstall, dep)
+			depsToInstall = append(
+				depsToInstall,
+				installDebPkg{
+					Pkg: dep,
+				},
+			)
 		}
 	}
 

--- a/spec/pgxman.yaml.md
+++ b/spec/pgxman.yaml.md
@@ -19,9 +19,22 @@ and the targeting PostgreSQL versions.
 - **Type**: List of objects
 - **Required**: No
 - **Object Fields**:
-  - `name`: Specifies the name of the extension. Either the `name` or the `path` field must be present. (String, Optional)
-  - `version`: Specifies the version of the extension. This field is mandatory if the `name` field is provided. (String, Required if `name` is present)
-  - `path`: Provides the local path to the extension package. Either the `name` or the `path` field must be present. (String, Optional)
+  - `name`:
+    - **Description**: Specifies the name of the extension. Either the `name` or the `path` field must be present.
+    - **Type**: String
+    - **Required**: No
+  - `version`:
+    - **Description**: Specifies the version of the extension. This field is mandatory if the `name` field is provided.
+    - **Type**: String
+    - **Required**: Yes if `name` is present
+  - `path`:
+    - **Description**: Specifies the local path to the extension package. Either the `name` or the `path` field must be present.
+    - **Type**: String
+    - **Required**: No
+  - `options`:
+    - **Description**: Specifies the options to be passed to corresponding package manager when installing the extension.
+    - **Type**: List of strings
+    - **Required**: No
 
 ### `pgVersions`
 


### PR DESCRIPTION
Support options when installing an extension. This cleans up https://github.com/hydradatabase/hydra/compare/owenthereal/pgxman_exts?expand=1#diff-7eceef652280b836b2fe8dc61749b5491185754c8bbf9a7784b1339d8be8f831R30 where `Dpkg::Options::="--force-overwrite"` can be passed to `pgxman.yaml`. Passing the `force-overwrite` options to apt is a short term workaround before building mutilple debian packages with one buildkit yaml file is supported which will take some time to think through.