### PR TITLE
[HYD-562] Remove duplicated apt sources

### DIFF
--- a/extension.go
+++ b/extension.go
@@ -432,6 +432,27 @@ func (repo AptRepository) Name() string {
 	return "pgxman-" + repo.ID
 }
 
+func (repo AptRepository) URIsString() string {
+	return strings.Join(repo.URIs, " ")
+}
+
+func (repo AptRepository) SuitesString() string {
+	return strings.Join(repo.Suites, " ")
+}
+
+func (repo AptRepository) TypesString() string {
+	var types []string
+	for _, t := range repo.Types {
+		types = append(types, string(t))
+	}
+
+	return strings.Join(types, " ")
+}
+
+func (repo AptRepository) ComponentsString() string {
+	return strings.Join(repo.Components, " ")
+}
+
 func (repo AptRepository) Validate() error {
 	if repo.ID == "" {
 		return fmt.Errorf("apt repository id is required")

--- a/internal/plugin/debian/apt_test.go
+++ b/internal/plugin/debian/apt_test.go
@@ -1,0 +1,58 @@
+package debian
+
+import (
+	"os"
+	"path/filepath"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+)
+
+func Test_exitingAptSourceURIs(t *testing.T) {
+	assert := assert.New(t)
+
+	sourceDir := t.TempDir()
+
+	err := os.WriteFile(
+		filepath.Join(sourceDir, "pgxman-core.sources"),
+		[]byte(`
+Types: deb
+URIs: https://pgxman-buildkit-debian.s3.amazonaws.com
+Suites: stable
+Components: main
+Signed-By: /usr/share/keyrings/pgxman.gpg
+`),
+		0644,
+	)
+	assert.NoError(err)
+
+	err = os.WriteFile(
+		filepath.Join(sourceDir, "pgxman-pgdg.sources"),
+		[]byte(`
+Types: deb
+URIs: https://apt.postgresql.org/pub/repos/apt
+Suites: bookworm-pgdg
+Components: main
+Signed-By: /usr/share/postgresql-common/pgdg/apt.postgresql.org.gpg
+
+Types: deb
+URIs: https://apt.postgresql.org/pub/repos/apt1
+Suites: bookworm-pgdg
+Components: main
+Signed-By: /usr/share/postgresql-common/pgdg/apt.postgresql.org.gpg
+`),
+		0644,
+	)
+	assert.NoError(err)
+
+	uris, err := exitingAptSourceURIs(sourceDir)
+	assert.NoError(err)
+
+	assert.Equal(
+		map[string]struct{}{
+			"https://apt.postgresql.org/pub/repos/apt":  struct{}{},
+			"https://apt.postgresql.org/pub/repos/apt1": struct{}{},
+		},
+		uris,
+	)
+}

--- a/internal/plugin/debian/installer.go
+++ b/internal/plugin/debian/installer.go
@@ -81,9 +81,11 @@ func (i *DebianInstaller) Install(ctx context.Context, extFiles []pgxman.PGXManf
 		return nil
 	}
 
-	apt := &Apt{
-		Logger: i.Logger.WithGroup("apt"),
+	apt, err := NewApt(i.Logger.WithGroup("apt"))
+	if err != nil {
+		return err
 	}
+
 	aptSources, err := apt.GetChangedSources(ctx, aptRepos)
 	if err != nil {
 		return err

--- a/internal/plugin/debian/packager.go
+++ b/internal/plugin/debian/packager.go
@@ -198,9 +198,11 @@ func (p *DebianPackager) installBuildDependencies(ctx context.Context, ext pgxma
 	logger := p.Logger.With(slog.String("name", ext.Name), slog.String("version", ext.Version), slog.Any("deps", depsToInstall))
 	logger.Info("Installing build deps")
 
-	apt := &Apt{
-		Logger: logger,
+	apt, err := NewApt(logger)
+	if err != nil {
+		return err
 	}
+
 	sources, err := apt.ConvertSources(ctx, builder.AptRepositories)
 	if err != nil {
 		return err


### PR DESCRIPTION
Remove duplicated apt sources.

Got error:

```
Conflicting values set for option Signed-By regarding source https://apt.postgresql.org/pub/repos/apt/ bookworm-pgdg: /usr/share/postgresql-common/pgdg/apt.postgresql.org.gpg != /usr/share/keyrings/pgxman-pgdg-bookworm.asc

https://github.com/pgxman/buildkit/actions/runs/6411708224/job/17407704352?pr=22#step:7:300
```

Ref: https://github.com/pgxman/buildkit/pull/22