### PR TITLE
[HYD-560] Do not validate extension against the latest buildkit version when installing

### DIFF
--- a/internal/plugin/debian/apt_test.go
+++ b/internal/plugin/debian/apt_test.go
@@ -50,8 +50,8 @@ Signed-By: /usr/share/postgresql-common/pgdg/apt.postgresql.org.gpg
 
 	assert.Equal(
 		map[string]struct{}{
-			"https://apt.postgresql.org/pub/repos/apt":  struct{}{},
-			"https://apt.postgresql.org/pub/repos/apt1": struct{}{},
+			"https://apt.postgresql.org/pub/repos/apt":  {},
+			"https://apt.postgresql.org/pub/repos/apt1": {},
 		},
 		uris,
 	)

--- a/internal/plugin/debian/installer.go
+++ b/internal/plugin/debian/installer.go
@@ -54,7 +54,8 @@ func (i *DebianInstaller) Install(ctx context.Context, extFiles []pgxman.PGXManf
 					return fmt.Errorf("extension %q not found", extToInstall.Name)
 				}
 				if installableExt.Version != extToInstall.Version {
-					return fmt.Errorf("extension %q with version %q not available", extToInstall.Name, extToInstall.Version)
+					// TODO(owenthereal): validate old version when api is ready
+					i.Logger.Debug("extension version does not match the latest", "extension", extToInstall.Name, "version", extToInstall.Version, "latest", installableExt.Version)
 				}
 
 				for _, pgv := range extFile.PGVersions {


### PR DESCRIPTION
Do not validate extension against the latest buildkit version when installing. This allows for the installation of older extension versions. The command will fail at the `apt install` if the version doesn't exist:

```
$ pgxman install pgvector=1@15
The following Debian packages will be installed:
  postgresql-15-pgxman-pgvector=1
The following Apt repositories will be added or updated:
  pgxman-core
Do you want to continue? [Y/n] Y
Hit:1 http://deb.debian.org/debian bookworm InRelease
Hit:2 http://deb.debian.org/debian bookworm-updates InRelease
Hit:3 http://deb.debian.org/debian-security bookworm-security InRelease
Hit:4 https://apt.postgresql.org/pub/repos/apt bookworm-pgdg InRelease
Get:5 https://pgxman-buildkit-debian.s3.amazonaws.com/debian bookworm InRelease [3244 B]
Get:6 https://pgxman-buildkit-debian.s3.amazonaws.com/debian bookworm/main arm64 Packages [4535 B]
Fetched 7779 B in 1s (11.9 kB/s)
Reading package lists... Done
Building dependency tree... Done
Reading state information... Done
All packages are up to date.
Reading package lists... Done
Building dependency tree... Done
Reading state information... Done
Package postgresql-15-pgxman-pgvector is not available, but is referred to by another package.
This may mean that the package is missing, has been obsoleted, or
is only available from another source

E: Version '1' for 'postgresql-15-pgxman-pgvector' was not found
Error: apt install: exit status 100
Usage:
  pgxman install [flags]
```