### PR TITLE
Makefile: add `all` -> `build` as first (default) goal

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -2,6 +2,9 @@ SHELL=/bin/bash -eo pipefail
 
 BIN_DIR ?= $(CURDIR)/bin
 export PATH := $(BIN_DIR):$(PATH)
+
+all: build
+
 .PHONY: tools
 tools:
 	# goreleaser


### PR DESCRIPTION
typical convention is running `make` will build the project. 

before this commit, the first goal, `tools`, was used by default, because it was first. 

FYI, calling the (first / default) goal `all` is just a convention, it is not a magic goal name.

https://stackoverflow.com/questions/2057689/how-does-make-app-know-default-target-to-build-if-no-target-is-specified