### PR TITLE
[HYD-566] Support building Rust-based extensions

### DIFF
--- a/builder.go
+++ b/builder.go
@@ -21,6 +21,10 @@ import (
 	"sigs.k8s.io/yaml"
 )
 
+const (
+	buildWorkspaceDir = "/root/workspace"
+)
+
 type BuilderOptions struct {
 	ExtDir    string
 	Debug     bool
@@ -125,6 +129,8 @@ func (b *dockerBuilder) runDockerBuild(ctx context.Context, ext Extension, dstDi
 				"--set",
 				fmt.Sprintf("*.platform=%s", dockerPlatforms(ext)),
 				"--set",
+				fmt.Sprintf("*.args.WORKSPACE_DIR=%s", buildWorkspaceDir),
+				"--set",
 				"export.output=type=local,dest=./out",
 			},
 		)...,
@@ -213,6 +219,8 @@ func (b *dockerBuilder) dockerBakeArgs(ext Extension, targets []string, extraArg
 			fmt.Sprintf("%s.args.BUILD_IMAGE=%s", bakeTargetName, builder.Image),
 			"--set",
 			fmt.Sprintf("%s.args.BUILD_SHA=%s", bakeTargetName, sha),
+			"--set",
+			fmt.Sprintf("%s.args.WORKSPACE_DIR=%s", bakeTargetName, buildWorkspaceDir),
 		)
 
 		if b.BuilderOptions.Debug {
@@ -243,6 +251,10 @@ func (b *dockerBuilder) dockerBakeArgs(ext Extension, targets []string, extraArg
 		for _, cacheTo := range b.CacheTo {
 			args = append(args, "--set", fmt.Sprintf("*.cache-to=%s", cacheTo))
 		}
+	}
+
+	if b.Debug {
+		args = append(args, "--progress=plain")
 	}
 
 	args = append(args, targets...)

--- a/docker/Dockerfile.debian
+++ b/docker/Dockerfile.debian
@@ -21,6 +21,7 @@ RUN set -eux; \
     gnupg2 \
     libcurl4-openssl-dev \
     libssl-dev \
+    locales \
     lsb-release \
     make \
     ninja-build \
@@ -33,13 +34,25 @@ RUN set -eux; \
     ; \
     sh /usr/share/postgresql-common/pgdg/apt.postgresql.org.sh -y; \
     apt-get update; \
+    apt-get upgrade -y; \
     apt-get install -y --no-install-recommends \
+    postgresql-all \
     postgresql-server-dev-all \
     ; \
     apt-get clean
 
+RUN set -eux; \
+    locale-gen en_US.UTF-8; \
+    echo "LC_ALL=en_US.UTF-8" >> /etc/environment; \
+    echo "en_US.UTF-8 UTF-8" >> /etc/locale.gen; \
+    echo "LANG=en_US.UTF-8" > /etc/locale.conf
+
 # patch pg_buildext to use multiple processors
 COPY patch/make_pg_buildext_parallel.patch /tmp
 RUN patch `which pg_buildext` < /tmp/make_pg_buildext_parallel.patch
+
+# rustup
+RUN curl --proto '=https' --tlsv1.2 -sSf https://sh.rustup.rs | sh -s -- -y --no-modify-path --profile minimal
+ENV PATH=/root/.cargo/bin:$PATH
 
 COPY --from=pgxman /go/bin/* /usr/local/bin/

--- a/internal/plugin/debian/apt.go
+++ b/internal/plugin/debian/apt.go
@@ -70,6 +70,10 @@ type AptSource struct {
 	KeyContent    []byte
 }
 
+func (a AptSource) String() string {
+	return fmt.Sprintf("%s (%s)", a.Name, a.SourcePath)
+}
+
 type AptPackage struct {
 	Pkg  string
 	Opts []string

--- a/internal/template/docker/Dockerfile
+++ b/internal/template/docker/Dockerfile
@@ -5,10 +5,12 @@ FROM $BUILD_IMAGE as build
 
 ARG BUILD_SHA
 ARG PGXMAN_PACK_ARGS=""
+ARG WORKSPACE_DIR
 
-COPY source.tar.gz /workspace/source.tar.gz
-COPY extension.yaml /workspace/extension.yaml
-WORKDIR /workspace
+RUN mkdir ${WORKSPACE_DIR}
+WORKDIR ${WORKSPACE_DIR}
+COPY source.tar.gz ${WORKSPACE_DIR}/source.tar.gz
+COPY extension.yaml ${WORKSPACE_DIR}/extension.yaml
 
 RUN pgxman-pack init $PGXMAN_PACK_ARGS
 RUN pgxman-pack pre $PGXMAN_PACK_ARGS

--- a/internal/template/docker/Dockerfile.export
+++ b/internal/template/docker/Dockerfile.export
@@ -2,12 +2,14 @@
 
 FROM ubuntu AS merge
 
+ARG WORKSPACE_DIR
+
 {{- if .ExportDebianBookwormArtifacts }}
-COPY --from=debian-bookworm /workspace/target/*.deb  /out/debian/bookworm/
+COPY --from=debian-bookworm ${WORKSPACE_DIR}/target/*.deb  /out/debian/bookworm/
 {{- end }}
 
 {{- if .ExportUbuntuJammyArtifacts }}
-COPY --from=ubuntu-jammy /workspace/target/*.deb  /out/ubuntu/jammy/
+COPY --from=ubuntu-jammy ${WORKSPACE_DIR}/target/*.deb  /out/ubuntu/jammy/
 {{- end }}
 
 FROM ubuntu AS export


### PR DESCRIPTION
This PR makes it possible to build a Rust-based extension like https://github.com/pgxman/buildkit/compare/owenthereal/pg_graphql?expand=1. It includes the following changes:

* Add Rustup to build image
* Fix the locales warnings when running `debuild`
* `debuild` now preserves all env vars from the build environment, without this, Rust build fails to find paths
