### PR TITLE
docs: replace relative links in generated docs

### DIFF
--- a/docs/cli/pgxman.mdx
+++ b/docs/cli/pgxman.mdx
@@ -13,12 +13,12 @@ PostgreSQL Extension Manager
 
 ### SEE ALSO
 
-* [pgxman build](pgxman_build)	 - Build extension according to the configuration file
-* [pgxman bundle](pgxman_bundle)	 - Manage PostgreSQL extensions from a bundle file
-* [pgxman container](pgxman_container)	 - Run pgxman in a container
-* [pgxman doctor](pgxman_doctor)	 - Troubleshoot your system for potential problems
-* [pgxman init](pgxman_init)	 - Create a buildkit file
-* [pgxman install](pgxman_install)	 - Install PostgreSQL extensions
-* [pgxman search](pgxman_search)	 - Search for PostgreSQL extensions
-* [pgxman upgrade](pgxman_upgrade)	 - Upgrade PostgreSQL extensions
+* [pgxman build](/cli/pgxman_build)	 - Build extension according to the configuration file
+* [pgxman bundle](/cli/pgxman_bundle)	 - Manage PostgreSQL extensions from a bundle file
+* [pgxman container](/cli/pgxman_container)	 - Run pgxman in a container
+* [pgxman doctor](/cli/pgxman_doctor)	 - Troubleshoot your system for potential problems
+* [pgxman init](/cli/pgxman_init)	 - Create a buildkit file
+* [pgxman install](/cli/pgxman_install)	 - Install PostgreSQL extensions
+* [pgxman search](/cli/pgxman_search)	 - Search for PostgreSQL extensions
+* [pgxman upgrade](/cli/pgxman_upgrade)	 - Upgrade PostgreSQL extensions
 

--- a/docs/cli/pgxman_build.mdx
+++ b/docs/cli/pgxman_build.mdx
@@ -27,5 +27,5 @@ pgxman build [flags]
 
 ### SEE ALSO
 
-* [pgxman](pgxman)	 - PostgreSQL Extension Manager
+* [pgxman](/cli/pgxman)	 - PostgreSQL Extension Manager
 

--- a/docs/cli/pgxman_bundle.mdx
+++ b/docs/cli/pgxman_bundle.mdx
@@ -55,5 +55,5 @@ pgxman bundle [flags]
 
 ### SEE ALSO
 
-* [pgxman](pgxman)	 - PostgreSQL Extension Manager
+* [pgxman](/cli/pgxman)	 - PostgreSQL Extension Manager
 

--- a/docs/cli/pgxman_container.mdx
+++ b/docs/cli/pgxman_container.mdx
@@ -18,8 +18,8 @@ Run pgxman in a container
 
 ### SEE ALSO
 
-* [pgxman](pgxman)	 - PostgreSQL Extension Manager
-* [pgxman container install](pgxman_container_install)	 - Install PostgreSQL extensions in a container
-* [pgxman container teardown](pgxman_container_teardown)	 - Tear down a container
-* [pgxman container upgrade](pgxman_container_upgrade)	 - Upgrade PostgreSQL extensions in a container
+* [pgxman](/cli/pgxman)	 - PostgreSQL Extension Manager
+* [pgxman container install](/cli/pgxman_container_install)	 - Install PostgreSQL extensions in a container
+* [pgxman container teardown](/cli/pgxman_container_teardown)	 - Tear down a container
+* [pgxman container upgrade](/cli/pgxman_container_upgrade)	 - Upgrade PostgreSQL extensions in a container
 

--- a/docs/cli/pgxman_container_install.mdx
+++ b/docs/cli/pgxman_container_install.mdx
@@ -49,5 +49,5 @@ pgxman container install [flags]
 
 ### SEE ALSO
 
-* [pgxman container](pgxman_container)	 - Run pgxman in a container
+* [pgxman container](/cli/pgxman_container)	 - Run pgxman in a container
 

--- a/docs/cli/pgxman_container_teardown.mdx
+++ b/docs/cli/pgxman_container_teardown.mdx
@@ -37,5 +37,5 @@ pgxman container teardown pgxman_runner_15 pgxman_runner_16
 
 ### SEE ALSO
 
-* [pgxman container](pgxman_container)	 - Run pgxman in a container
+* [pgxman container](/cli/pgxman_container)	 - Run pgxman in a container
 

--- a/docs/cli/pgxman_container_upgrade.mdx
+++ b/docs/cli/pgxman_container_upgrade.mdx
@@ -49,5 +49,5 @@ pgxman container upgrade [flags]
 
 ### SEE ALSO
 
-* [pgxman container](pgxman_container)	 - Run pgxman in a container
+* [pgxman container](/cli/pgxman_container)	 - Run pgxman in a container
 

--- a/docs/cli/pgxman_doctor.mdx
+++ b/docs/cli/pgxman_doctor.mdx
@@ -26,5 +26,5 @@ pgxman doctor [flags]
 
 ### SEE ALSO
 
-* [pgxman](pgxman)	 - PostgreSQL Extension Manager
+* [pgxman](/cli/pgxman)	 - PostgreSQL Extension Manager
 

--- a/docs/cli/pgxman_init.mdx
+++ b/docs/cli/pgxman_init.mdx
@@ -27,5 +27,5 @@ pgxman init [flags]
 
 ### SEE ALSO
 
-* [pgxman](pgxman)	 - PostgreSQL Extension Manager
+* [pgxman](/cli/pgxman)	 - PostgreSQL Extension Manager
 

--- a/docs/cli/pgxman_install.mdx
+++ b/docs/cli/pgxman_install.mdx
@@ -55,5 +55,5 @@ pgxman install [flags]
 
 ### SEE ALSO
 
-* [pgxman](pgxman)	 - PostgreSQL Extension Manager
+* [pgxman](/cli/pgxman)	 - PostgreSQL Extension Manager
 

--- a/docs/cli/pgxman_search.mdx
+++ b/docs/cli/pgxman_search.mdx
@@ -38,5 +38,5 @@ pgxman search [<query>] [flags]
 
 ### SEE ALSO
 
-* [pgxman](pgxman)	 - PostgreSQL Extension Manager
+* [pgxman](/cli/pgxman)	 - PostgreSQL Extension Manager
 

--- a/docs/cli/pgxman_upgrade.mdx
+++ b/docs/cli/pgxman_upgrade.mdx
@@ -55,5 +55,5 @@ pgxman upgrade [flags]
 
 ### SEE ALSO
 
-* [pgxman](pgxman)	 - PostgreSQL Extension Manager
+* [pgxman](/cli/pgxman)	 - PostgreSQL Extension Manager
 

--- a/docs/script/md-to-mdx
+++ b/docs/script/md-to-mdx
@@ -10,5 +10,5 @@ title: $command
 ---
 
 EOF
-  tail +3 $f | sed 's/\.md)/)/g' >> ${f}x
+  sed -E -e '1,2d' -e 's/\.md)/)/g' -e 's#\(pgxman#(/cli/pgxman#g' $f >> ${f}x
 done


### PR DESCRIPTION
for some reason these links 'worked' but were being detected by mintlify as not being part of the site, so they would open in a new tab.

this also satisfies all issues reported by `mintlify broken-links`.

----

more `sed`!