### PR TITLE
[HYD-702] Warn about incompatible pg version

### DIFF
--- a/internal/cmd/pgxman/installupgrade.go
+++ b/internal/cmd/pgxman/installupgrade.go
@@ -8,6 +8,7 @@ import (
 	"os"
 	"path/filepath"
 	"regexp"
+	"slices"
 	"strings"
 	"text/template"
 	"time"
@@ -265,6 +266,10 @@ func LockPGXManfile(f *pgxman.PGXManfile, logger *log.Logger) error {
 			if installableExt.Version != ext.Version {
 				// TODO(owenthereal): validate old version when api is ready
 				logger.Debug("extension version does not match the latest", "extension", ext.Name, "version", ext.Version, "latest", installableExt.Version)
+			}
+
+			if !slices.Contains(installableExt.PGVersions, f.Postgres.Version) {
+				return fmt.Errorf("the extension version to install is incompatible with PostgreSQL %s", f.Postgres.Version)
 			}
 		}
 


### PR DESCRIPTION
Quickly did this:

```
root@ee60047cd2bd:/# pgxman install pg_hint_plan-13
Error: the extension version to install is incompatible with PostgreSQL 15
root@ee60047cd2bd:/# pgxman install pg_hint_plan-14
Error: the extension version to install is incompatible with PostgreSQL 15
root@ee60047cd2bd:/# pgxman install pg_hint_plan-15
The following Debian packages will be installed:
  postgresql-15-pgxman-pg-hint-plan-15=1.5.0-1
The following Apt repositories will be added or updated:
  pgxman-core
Do you want to continue? [Y/n]
[✓] pg_hint_plan-15: https://pgx.sh/pg_hint_plan-15
```