### PR TITLE
More descriptive pg version incompatible message

### DIFF
--- a/internal/cmd/pgxman/installupgrade.go
+++ b/internal/cmd/pgxman/installupgrade.go
@@ -279,7 +279,7 @@ func LockPGXManfile(f *pgxman.PGXManfile, logger *log.Logger) error {
 			}
 
 			if !slices.Contains(installableExt.PGVersions, f.Postgres.Version) {
-				return fmt.Errorf("the extension version to install is incompatible with PostgreSQL %s", f.Postgres.Version)
+				return fmt.Errorf("%s %s is incompatible with PostgreSQL %s", ext.Name, ext.Version, f.Postgres.Version)
 			}
 		}
 


### PR DESCRIPTION
```
$ pgxman install pgrouting
Error: pgrouting 3.5.1 is incompatible with PostgreSQL 15
```