### PR TITLE
[HYD-737] Use GET /extensions/{slug} endpoint when installing extensions

### DIFF
--- a/builder.go
+++ b/builder.go
@@ -286,7 +286,7 @@ func buildSHA(ext Extension) string {
 
 func dockerDebugImage(p Platform, ext Extension) string {
 	var (
-		imagePath = strings.ReplaceAll(string(p), ":", "/")
+		imagePath = strings.ReplaceAll(string(p), "_", "/")
 		///  Docker tags must match the regex [a-zA-Z0-9_.-], which allows alphanumeric characters, dots, underscores, and hyphens.
 		tag = strings.ReplaceAll(ext.Version, "+", "-")
 	)
@@ -304,7 +304,7 @@ func dockerBakeTargets(ext Extension) []string {
 }
 
 func dockerBakeTargetFromBuilderID(p Platform) string {
-	return strings.ReplaceAll(string(p), ":", "-")
+	return strings.ReplaceAll(string(p), "_", "-")
 }
 
 type dockerFileExtension struct {

--- a/builder.go
+++ b/builder.go
@@ -284,9 +284,9 @@ func buildSHA(ext Extension) string {
 	return fmt.Sprintf("%x", sha1.Sum(extb))
 }
 
-func dockerDebugImage(bt ExtensionBuilderType, ext Extension) string {
+func dockerDebugImage(p Platform, ext Extension) string {
 	var (
-		imagePath = strings.ReplaceAll(string(bt), ":", "/")
+		imagePath = strings.ReplaceAll(string(p), ":", "/")
 		///  Docker tags must match the regex [a-zA-Z0-9_.-], which allows alphanumeric characters, dots, underscores, and hyphens.
 		tag = strings.ReplaceAll(ext.Version, "+", "-")
 	)
@@ -303,8 +303,8 @@ func dockerBakeTargets(ext Extension) []string {
 	return result
 }
 
-func dockerBakeTargetFromBuilderID(bt ExtensionBuilderType) string {
-	return strings.ReplaceAll(string(bt), ":", "-")
+func dockerBakeTargetFromBuilderID(p Platform) string {
+	return strings.ReplaceAll(string(p), ":", "-")
 }
 
 type dockerFileExtension struct {
@@ -313,7 +313,7 @@ type dockerFileExtension struct {
 
 func (e dockerFileExtension) ExportDebianBookwormArtifacts() bool {
 	if builders := e.Builders; builders != nil {
-		return builders.HasBuilder(ExtensionBuilderDebianBookworm)
+		return builders.HasBuilder(PlatformDebianBookworm)
 	}
 
 	return false
@@ -321,7 +321,7 @@ func (e dockerFileExtension) ExportDebianBookwormArtifacts() bool {
 
 func (e dockerFileExtension) ExportUbuntuJammyArtifacts() bool {
 	if builders := e.Builders; builders != nil {
-		return builders.HasBuilder(ExtensionBuilderUbuntuJammy)
+		return builders.HasBuilder(PlatformUbuntuJammy)
 	}
 
 	return false

--- a/docs/spec/buildkit.mdx
+++ b/docs/spec/buildkit.mdx
@@ -263,14 +263,6 @@ build: |
 - **Supported Values**: `amd64`, `arm64`
 - **Default Values**: `amd64`, `arm64`
 
-## `platform`
-
-- **Description**: Lists the platforms that the extension supports. Currently, only Linux is supported.
-- **Type**: List of strings
-- **Required**: No
-- **Supported Values**: `linux`
-- **Default Values**: `linux`
-
 ## `formats`
 
 - **Description**: Lists the formats in which the built extension can be packaged. Currently, only Debian packages (`deb`) are supported.

--- a/extension.go
+++ b/extension.go
@@ -357,6 +357,8 @@ func (ebs ExtensionBuilders) Current() AptExtensionBuilder {
 		builder = ebs.DebianBookworm
 	case PlatformUbuntuJammy:
 		builder = ebs.UbuntuJammy
+	default:
+		panic("unsupported platform: " + p)
 	}
 
 	return ebs.newBuilder(p, builder)

--- a/extension.go
+++ b/extension.go
@@ -362,15 +362,15 @@ func (ebs ExtensionBuilders) Current() AptExtensionBuilder {
 	return ebs.newBuilder(p, builder)
 }
 
-func (ebs ExtensionBuilders) newBuilder(os Platform, builder *AptExtensionBuilder) AptExtensionBuilder {
+func (ebs ExtensionBuilders) newBuilder(p Platform, builder *AptExtensionBuilder) AptExtensionBuilder {
 	image := builder.Image
 	if image == "" {
-		image = extensionBuilderImages[os]
+		image = extensionBuilderImages[p]
 	}
 
 	return AptExtensionBuilder{
 		ExtensionBuilder: ExtensionBuilder{
-			Type:              os,
+			Type:              p,
 			Image:             image,
 			BuildDependencies: builder.BuildDependencies,
 			RunDependencies:   builder.RunDependencies,
@@ -521,8 +521,8 @@ type Platform string
 
 const (
 	PlatformUnsupported    Platform = "unsupported"
-	PlatformDebianBookworm Platform = "debian:bookworm"
-	PlatformUbuntuJammy    Platform = "ubuntu:jammy"
+	PlatformDebianBookworm Platform = "debian_bookworm"
+	PlatformUbuntuJammy    Platform = "ubuntu_jammy"
 	PlatformDarwin         Platform = "darwin"
 )
 

--- a/extension.go
+++ b/extension.go
@@ -23,19 +23,18 @@ func NewDefaultExtension() Extension {
 		APIVersion: DefaultExtensionAPIVersion,
 		PGVersions: SupportedPGVersions,
 		Arch:       []Arch{Arch(runtime.GOARCH)},
-		Platform:   SupprtedPlatforms,
 		Formats:    SupportedFormats,
 		Builders: &ExtensionBuilders{
 			DebianBookworm: &AptExtensionBuilder{
 				ExtensionBuilder: ExtensionBuilder{
-					Type:  ExtensionBuilderDebianBookworm,
-					Image: fmt.Sprintf("%s:%s", extensionBuilderImages[ExtensionBuilderDebianBookworm], ImageTag()),
+					Type:  PlatformDebianBookworm,
+					Image: fmt.Sprintf("%s:%s", extensionBuilderImages[PlatformDebianBookworm], ImageTag()),
 				},
 			},
 			UbuntuJammy: &AptExtensionBuilder{
 				ExtensionBuilder: ExtensionBuilder{
-					Type:  ExtensionBuilderUbuntuJammy,
-					Image: fmt.Sprintf("%s:%s", extensionBuilderImages[ExtensionBuilderUbuntuJammy], ImageTag()),
+					Type:  PlatformUbuntuJammy,
+					Image: fmt.Sprintf("%s:%s", extensionBuilderImages[PlatformUbuntuJammy], ImageTag()),
 				},
 			},
 		},
@@ -56,7 +55,6 @@ type Extension struct {
 	// optional
 	Builders          *ExtensionBuilders `json:"builders,omitempty"`
 	Arch              []Arch             `json:"arch,omitempty"`
-	Platform          []Platform         `json:"platform,omitempty"`
 	Formats           []Format           `json:"formats,omitempty"`
 	Description       string             `json:"description,omitempty"`
 	License           string             `json:"license,omitempty"`
@@ -142,12 +140,6 @@ func (ext Extension) Validate() error {
 		}
 	}
 
-	for _, p := range ext.Platform {
-		if !slices.Contains(SupprtedPlatforms, p) {
-			return fmt.Errorf("unsupported platform: %s", p)
-		}
-	}
-
 	builders := ext.Builders.Available()
 	if len(builders) == 0 {
 		return fmt.Errorf("at least one extension builder is required")
@@ -227,16 +219,6 @@ var (
 	SupportedFormats = []Format{FormatDeb}
 )
 
-type Platform string
-
-const (
-	PlatformLinux Platform = "linux"
-)
-
-var (
-	SupprtedPlatforms = []Platform{PlatformLinux}
-)
-
 type PGVersion string
 
 const (
@@ -311,33 +293,24 @@ func (s BuildScript) Validate() error {
 }
 
 var (
-	extensionBuilderImages = map[ExtensionBuilderType]string{
-		ExtensionBuilderDebianBookworm: "ghcr.io/pgxman/builder/debian/bookworm",
-		ExtensionBuilderUbuntuJammy:    "ghcr.io/pgxman/builder/ubuntu/jammy",
+	extensionBuilderImages = map[Platform]string{
+		PlatformDebianBookworm: "ghcr.io/pgxman/builder/debian/bookworm",
+		PlatformUbuntuJammy:    "ghcr.io/pgxman/builder/ubuntu/jammy",
 	}
 )
 
-type ExtensionBuilderType string
-
-const (
-	ExtensionBuilderUnsupported    ExtensionBuilderType = "unsupported"
-	ExtensionBuilderDebianBookworm ExtensionBuilderType = "debian:bookworm"
-	ExtensionBuilderUbuntuJammy    ExtensionBuilderType = "ubuntu:jammy"
-	ExtensionBuilderDarwin         ExtensionBuilderType = "darwin"
-)
-
-type ErrUnsupportedExtensionBuilder struct {
+type ErrUnsupportedPlatform struct {
 	osVendor  string
 	osVersion string
 }
 
-func (e *ErrUnsupportedExtensionBuilder) Error() string {
+func (e *ErrUnsupportedPlatform) Error() string {
 	builder := e.osVendor
 	if e.osVersion != "" {
 		builder += ":" + e.osVersion
 	}
 
-	return fmt.Sprintf("Unsupported builder: %s", builder)
+	return fmt.Sprintf("Unsupported platform: %s", builder)
 }
 
 type ExtensionBuilders struct {
@@ -345,11 +318,11 @@ type ExtensionBuilders struct {
 	UbuntuJammy    *AptExtensionBuilder `json:"ubuntu:jammy,omitempty"`
 }
 
-func (ebs ExtensionBuilders) HasBuilder(bt ExtensionBuilderType) bool {
-	switch bt {
-	case ExtensionBuilderDebianBookworm:
+func (ebs ExtensionBuilders) HasBuilder(p Platform) bool {
+	switch p {
+	case PlatformDebianBookworm:
 		return ebs.DebianBookworm != nil
-	case ExtensionBuilderUbuntuJammy:
+	case PlatformUbuntuJammy:
 		return ebs.UbuntuJammy != nil
 	}
 
@@ -361,10 +334,10 @@ func (ebs ExtensionBuilders) Available() []AptExtensionBuilder {
 	var result []AptExtensionBuilder
 
 	if builder := ebs.DebianBookworm; builder != nil {
-		result = append(result, ebs.newBuilder(ExtensionBuilderDebianBookworm, builder))
+		result = append(result, ebs.newBuilder(PlatformDebianBookworm, builder))
 	}
 	if builder := ebs.UbuntuJammy; builder != nil {
-		result = append(result, ebs.newBuilder(ExtensionBuilderUbuntuJammy, builder))
+		result = append(result, ebs.newBuilder(PlatformUbuntuJammy, builder))
 	}
 
 	return result
@@ -373,23 +346,23 @@ func (ebs ExtensionBuilders) Available() []AptExtensionBuilder {
 // Current returns the extension builder for the current os.
 // It panics if no extension builder is available.
 func (ebs ExtensionBuilders) Current() AptExtensionBuilder {
-	bt, err := DetectExtensionBuilder()
+	p, err := DetectPlatform()
 	if err != nil {
 		panic(err.Error())
 	}
 
 	var builder *AptExtensionBuilder
-	switch bt {
-	case ExtensionBuilderDebianBookworm:
+	switch p {
+	case PlatformDebianBookworm:
 		builder = ebs.DebianBookworm
-	case ExtensionBuilderUbuntuJammy:
+	case PlatformUbuntuJammy:
 		builder = ebs.UbuntuJammy
 	}
 
-	return ebs.newBuilder(bt, builder)
+	return ebs.newBuilder(p, builder)
 }
 
-func (ebs ExtensionBuilders) newBuilder(os ExtensionBuilderType, builder *AptExtensionBuilder) AptExtensionBuilder {
+func (ebs ExtensionBuilders) newBuilder(os Platform, builder *AptExtensionBuilder) AptExtensionBuilder {
 	image := builder.Image
 	if image == "" {
 		image = extensionBuilderImages[os]
@@ -407,10 +380,10 @@ func (ebs ExtensionBuilders) newBuilder(os ExtensionBuilderType, builder *AptExt
 }
 
 type ExtensionBuilder struct {
-	Type              ExtensionBuilderType `json:"-"`
-	Image             string               `json:"image,omitempty"`
-	BuildDependencies []string             `json:"buildDependencies,omitempty"`
-	RunDependencies   []string             `json:"runDependencies,omitempty"`
+	Type              Platform `json:"-"`
+	Image             string   `json:"image,omitempty"`
+	BuildDependencies []string `json:"buildDependencies,omitempty"`
+	RunDependencies   []string `json:"runDependencies,omitempty"`
 }
 
 type AptExtensionBuilder struct {
@@ -544,7 +517,16 @@ const (
 	AptRepositorySignedKeyFormatGpg AptRepositorySignedKeyFormat = "gpg"
 )
 
-func DetectExtensionBuilder() (ExtensionBuilderType, error) {
+type Platform string
+
+const (
+	PlatformUnsupported    Platform = "unsupported"
+	PlatformDebianBookworm Platform = "debian:bookworm"
+	PlatformUbuntuJammy    Platform = "ubuntu:jammy"
+	PlatformDarwin         Platform = "darwin"
+)
+
+func DetectPlatform() (Platform, error) {
 	info := osx.Sysinfo()
 
 	var (
@@ -557,18 +539,18 @@ func DetectExtensionBuilder() (ExtensionBuilderType, error) {
 	}
 
 	if vendor == "debian" && version == "12" {
-		return ExtensionBuilderDebianBookworm, nil
+		return PlatformDebianBookworm, nil
 	}
 
 	if vendor == "ubuntu" && version == "22.04" {
-		return ExtensionBuilderUbuntuJammy, nil
+		return PlatformUbuntuJammy, nil
 	}
 
 	if vendor == "darwin" {
-		return ExtensionBuilderDarwin, nil
+		return PlatformDarwin, nil
 	}
 
-	return ExtensionBuilderUnsupported, &ErrUnsupportedExtensionBuilder{osVendor: vendor, osVersion: version}
+	return PlatformUnsupported, &ErrUnsupportedPlatform{osVendor: vendor, osVersion: version}
 }
 
 type fileExtensionSource struct {

--- a/internal/cmd/pgxman/pack.go
+++ b/internal/cmd/pgxman/pack.go
@@ -92,7 +92,11 @@ func runPackInstall(cmd *cobra.Command, args []string) error {
 		return err
 	}
 
-	exts, err := LockExtensions(installExts(*b), log.NewTextLogger())
+	locker, err := NewExtensionLocker(log.NewTextLogger())
+	if err != nil {
+		return err
+	}
+	exts, err := locker.Lock(cmd.Context(), installExts(*b))
 	if err != nil {
 		return err
 	}

--- a/internal/plugin/debian/apt.go
+++ b/internal/plugin/debian/apt.go
@@ -381,7 +381,7 @@ func writeFile(path string, content []byte) error {
 }
 
 func coreAptRepos() ([]pgxman.AptRepository, error) {
-	bt, err := pgxman.DetectPlatform()
+	p, err := pgxman.DetectPlatform()
 	if err != nil {
 		return nil, fmt.Errorf("detect platform: %s", err)
 	}
@@ -391,7 +391,7 @@ func coreAptRepos() ([]pgxman.AptRepository, error) {
 		codename string
 	)
 
-	switch bt {
+	switch p {
 	case pgxman.PlatformDebianBookworm:
 		prefix = "debian"
 		codename = "bookworm"

--- a/internal/plugin/debian/apt.go
+++ b/internal/plugin/debian/apt.go
@@ -381,7 +381,7 @@ func writeFile(path string, content []byte) error {
 }
 
 func coreAptRepos() ([]pgxman.AptRepository, error) {
-	bt, err := pgxman.DetectExtensionBuilder()
+	bt, err := pgxman.DetectPlatform()
 	if err != nil {
 		return nil, fmt.Errorf("detect platform: %s", err)
 	}
@@ -392,10 +392,10 @@ func coreAptRepos() ([]pgxman.AptRepository, error) {
 	)
 
 	switch bt {
-	case pgxman.ExtensionBuilderDebianBookworm:
+	case pgxman.PlatformDebianBookworm:
 		prefix = "debian"
 		codename = "bookworm"
-	case pgxman.ExtensionBuilderUbuntuJammy:
+	case pgxman.PlatformUbuntuJammy:
 		prefix = "ubuntu"
 		codename = "jammy"
 	default:

--- a/internal/plugin/plugin.go
+++ b/internal/plugin/plugin.go
@@ -13,61 +13,61 @@ func init() {
 	debPkg := &debian.DebianPackager{
 		Logger: log.NewTextLogger(),
 	}
-	RegisterPackager(pgxman.ExtensionBuilderDebianBookworm, debPkg)
-	RegisterPackager(pgxman.ExtensionBuilderUbuntuJammy, debPkg)
+	RegisterPackager(pgxman.PlatformDebianBookworm, debPkg)
+	RegisterPackager(pgxman.PlatformUbuntuJammy, debPkg)
 
 	debInstaller := &debian.DebianInstaller{
 		Logger: log.NewTextLogger(),
 	}
-	RegisterInstaller(pgxman.ExtensionBuilderDebianBookworm, debInstaller)
-	RegisterInstaller(pgxman.ExtensionBuilderUbuntuJammy, debInstaller)
+	RegisterInstaller(pgxman.PlatformDebianBookworm, debInstaller)
+	RegisterInstaller(pgxman.PlatformUbuntuJammy, debInstaller)
 }
 
 var (
-	packagers  = make(map[pgxman.ExtensionBuilderType]pgxman.Packager)
-	installers = make(map[pgxman.ExtensionBuilderType]pgxman.Installer)
+	packagers  = make(map[pgxman.Platform]pgxman.Packager)
+	installers = make(map[pgxman.Platform]pgxman.Installer)
 )
 
-func RegisterPackager(bt pgxman.ExtensionBuilderType, packager pgxman.Packager) {
-	packagers[bt] = packager
+func RegisterPackager(p pgxman.Platform, packager pgxman.Packager) {
+	packagers[p] = packager
 }
 
 func GetPackager() (pgxman.Packager, error) {
-	bt, err := pgxman.DetectExtensionBuilder()
+	bt, err := pgxman.DetectPlatform()
 	if err != nil {
 		return nil, err
 	}
 
 	pkg := packagers[bt]
 	if pkg == nil {
-		return nil, &ErrUnsupportedPlugin{bt: bt}
+		return nil, &ErrUnsupportedPlugin{p: bt}
 	}
 
 	return pkg, nil
 }
 
-func RegisterInstaller(bt pgxman.ExtensionBuilderType, installer pgxman.Installer) {
-	installers[bt] = installer
+func RegisterInstaller(p pgxman.Platform, installer pgxman.Installer) {
+	installers[p] = installer
 }
 
 func GetInstaller() (pgxman.Installer, error) {
-	bt, err := pgxman.DetectExtensionBuilder()
+	bt, err := pgxman.DetectPlatform()
 	if err != nil {
 		return nil, err
 	}
 
 	i := installers[bt]
 	if i == nil {
-		return nil, &ErrUnsupportedPlugin{bt: bt}
+		return nil, &ErrUnsupportedPlugin{p: bt}
 	}
 
 	return i, nil
 }
 
 type ErrUnsupportedPlugin struct {
-	bt pgxman.ExtensionBuilderType
+	p pgxman.Platform
 }
 
 func (e *ErrUnsupportedPlugin) Error() string {
-	return fmt.Sprintf("Unsupported plugin: %s", e.bt)
+	return fmt.Sprintf("Unsupported plugin: %s", e.p)
 }

--- a/io.go
+++ b/io.go
@@ -93,11 +93,11 @@ func ReadExtension(path string, overrides map[string]any) (Extension, error) {
 	// Remove default builders that aren't declared
 	// so that mergo only merges those that are declared
 	if builders := ext.Builders; builders != nil {
-		if !builders.HasBuilder(ExtensionBuilderDebianBookworm) {
+		if !builders.HasBuilder(PlatformDebianBookworm) {
 			defExt.Builders.DebianBookworm = nil
 		}
 
-		if !builders.HasBuilder(ExtensionBuilderUbuntuJammy) {
+		if !builders.HasBuilder(PlatformUbuntuJammy) {
 			defExt.Builders.UbuntuJammy = nil
 		}
 	}


### PR DESCRIPTION
* Use GET /extensions/{slug} endpoint when installing extensions
* Consolidate `ExtensionBuilderType` to `Platform` and remove `platform` from buildkit spec. This field isn't necessary because `builders` can already specify the platform that an extension supports.