### PR TITLE
[HYD-746] Always add pgdg apt repo if missing

### DIFF
--- a/internal/plugin/debian/apt.go
+++ b/internal/plugin/debian/apt.go
@@ -414,6 +414,17 @@ func coreAptRepos() ([]pgxman.AptRepository, error) {
 				Format: pgxman.AptRepositorySignedKeyFormatGpg,
 			},
 		},
+		{
+			ID:         "pgdg",
+			Types:      []pgxman.AptRepositoryType{pgxman.AptRepositoryTypeDeb},
+			URIs:       []string{"https://apt.postgresql.org/pub/repos/apt"},
+			Suites:     []string{fmt.Sprintf("%s-pgdg", codename)},
+			Components: []string{"main"},
+			SignedKey: pgxman.AptRepositorySignedKey{
+				URL:    "https://www.postgresql.org/media/keys/ACCC4CF8.asc",
+				Format: pgxman.AptRepositorySignedKeyFormatAsc,
+			},
+		},
 	}, nil
 }
 


### PR DESCRIPTION
For ubuntu jammy, some extensions require some util dependencies from pgdg. For exmaple, for pgvector for pg 14, it requires postgresql-14-jit-llvm from pgdg:

```
time=2023-12-07T18:56:21.372Z level=DEBUG msg="The following information may help to resolve the situation:"
time=2023-12-07T18:56:21.372Z level=DEBUG msg=""
time=2023-12-07T18:56:21.372Z level=DEBUG msg="The following packages have unmet dependencies:"
time=2023-12-07T18:56:21.489Z level=DEBUG msg=" postgresql-14-pgxman-pgvector : Depends: postgresql-14-jit-llvm (>= 15)"
```

This makes sure pdgd is always there for utility dependencies like the above.