### PR TITLE
[HYD-756] Only persist pgxman.yaml when container install successes

### DIFF
--- a/internal/container/container_test.go
+++ b/internal/container/container_test.go
@@ -129,18 +129,21 @@ func Test_mergePackFile(t *testing.T) {
 			assert := assert.New(t)
 
 			dir := t.TempDir()
+			packFile := filepath.Join(dir, "pgxman.yaml")
+			tmpPackFile := filepath.Join(dir, "pgxman.yaml.tmp")
+
 			if c.ExistingPackFile != nil {
 				b, err := yaml.Marshal(c.ExistingPackFile)
 				assert.NoError(err)
 
-				err = os.WriteFile(filepath.Join(dir, "pgxman.yaml"), b, 0644)
+				err = os.WriteFile(packFile, b, 0644)
 				assert.NoError(err)
 			}
 
-			err := mergePackFile(c.NewPackFile, dir)
+			err := mergePackFile(c.NewPackFile, packFile, tmpPackFile)
 			assert.NoError(err)
 
-			b, err := os.ReadFile(filepath.Join(dir, "pgxman.yaml"))
+			b, err := os.ReadFile(tmpPackFile)
 			assert.NoError(err)
 
 			var got pgxman.Pack

--- a/internal/plugin/debian/installer.go
+++ b/internal/plugin/debian/installer.go
@@ -128,6 +128,7 @@ func newAptPackage(ext pgxman.InstallExtension) (AptPackage, error) {
 			Pkg:       ext.Path,
 			IsLocal:   true,
 			Opts:      ext.Options,
+			Repos:     coreAptRepos,
 			Overwrite: ext.Overwrite,
 		}
 	} else {

--- a/internal/template/runner/Dockerfile
+++ b/internal/template/runner/Dockerfile
@@ -2,6 +2,6 @@ FROM {{ .RunnerImage }}
 
 ARG PGXMAN_PACK_INSTALL_ARGS=""
 
-COPY pgxman.yaml /pgxman/pgxman.yaml
+COPY pgxman.yaml.tmp /pgxman/pgxman.yaml
 COPY files /pgxman/files
 RUN pgxman pack install --file /pgxman/pgxman.yaml --yes $PGXMAN_PACK_INSTALL_ARGS


### PR DESCRIPTION
Only persist pgxman.yaml when container install successes. Otherwise, the file lives as a tmp file