### PR TITLE
[HYD-764][HYD-763] Separate debian build by pg versions to allow for overwrite

### DIFF
--- a/builder.go
+++ b/builder.go
@@ -61,10 +61,6 @@ func (b *dockerBuilder) Build(ctx context.Context, ext Extension) error {
 	}()
 
 	b.logger.Debug("Building extension", "ext", ext, "workdir", workDir)
-	if err := b.fetchSource(ext, workDir); err != nil {
-		return fmt.Errorf("fetch source: %w", err)
-	}
-
 	if err := b.generateDockerFile(ext, workDir); err != nil {
 		return fmt.Errorf("generate Dockerfile: %w", err)
 	}
@@ -107,15 +103,6 @@ func (b *dockerBuilder) generateExtensionFile(ext Extension, dstDir string) erro
 	}
 
 	return os.WriteFile(filepath.Join(dstDir, "extension.yaml"), e, 0644)
-}
-
-func (b *dockerBuilder) fetchSource(ext Extension, dstDir string) error {
-	source, err := ext.ParseSource()
-	if err != nil {
-		return nil
-	}
-
-	return source.Archive(filepath.Join(dstDir, "source.tar.gz"))
 }
 
 func (b *dockerBuilder) runDockerBuild(ctx context.Context, ext Extension, dstDir string) error {

--- a/builder.go
+++ b/builder.go
@@ -60,7 +60,7 @@ func (b *dockerBuilder) Build(ctx context.Context, ext Extension) error {
 		}
 	}()
 
-	b.logger.Debug("Building extension", "ext", ext, "workdir", workDir)
+	b.logger.Debug("Building extension", "name", ext.Name, "workdir", workDir)
 	if err := b.generateDockerFile(ext, workDir); err != nil {
 		return fmt.Errorf("generate Dockerfile: %w", err)
 	}

--- a/go.mod
+++ b/go.mod
@@ -22,6 +22,7 @@ require (
 	github.com/stretchr/testify v1.8.4
 	github.com/zcalusic/sysinfo v1.0.2
 	golang.org/x/exp v0.0.0-20230522175609-2e198f4a06a1
+	golang.org/x/sync v0.3.0
 	golang.org/x/term v0.16.0
 	golang.org/x/text v0.14.0
 	sigs.k8s.io/yaml v1.4.0
@@ -69,7 +70,6 @@ require (
 	github.com/ulikunitz/xz v0.5.11 // indirect
 	github.com/xi2/xz v0.0.0-20171230120015-48954b6210f8 // indirect
 	golang.org/x/mod v0.12.0 // indirect
-	golang.org/x/sync v0.3.0 // indirect
 	golang.org/x/sys v0.16.0 // indirect
 	golang.org/x/tools v0.12.0 // indirect
 	gopkg.in/check.v1 v1.0.0-20200902074654-038fdea0a05b // indirect

--- a/internal/plugin/debian/apt.go
+++ b/internal/plugin/debian/apt.go
@@ -294,12 +294,10 @@ func (a *Apt) aptMarkUnhold(ctx context.Context, pkg AptPackage) error {
 }
 
 func (a *Apt) runAptCmd(ctx context.Context, command string, args ...string) (string, error) {
-	c := append([]string{command}, args...)
-
 	bw := bytes.NewBuffer(nil)
 	lw := a.Logger.Writer(slog.LevelDebug)
 
-	cmd := exec.CommandContext(ctx, c[0], c[1:]...)
+	cmd := exec.CommandContext(ctx, command, args...)
 	cmd.Env = append(os.Environ(), "DEBIAN_FRONTEND=noninteractive")
 	cmd.Stdout = io.MultiWriter(lw, bw)
 	cmd.Stderr = io.MultiWriter(lw, bw)

--- a/internal/plugin/debian/packager.go
+++ b/internal/plugin/debian/packager.go
@@ -292,10 +292,12 @@ func (p *DebianPackager) runScript(ctx context.Context, file string) error {
 	logger := p.Logger.With(slog.String("script", file))
 	logger.Info("Running script")
 
+	lw := logger.Writer(slog.LevelDebug)
+
 	runScript := exec.CommandContext(ctx, "bash", file)
 	runScript.Dir = filepath.Dir(file)
-	runScript.Stdout = os.Stdout
-	runScript.Stderr = os.Stderr
+	runScript.Stdout = lw
+	runScript.Stderr = lw
 
 	if err := runScript.Run(); err != nil {
 		return fmt.Errorf("running script: %w", err)
@@ -309,10 +311,12 @@ func (p *DebianPackager) buildDebian(ctx context.Context, ext pgxman.Extension, 
 	logger = logger.With("name", ext.Name, "version", ext.Version, "build-dir", buildDir)
 	logger.Info("Building debian package")
 
+	lw := logger.Writer(slog.LevelDebug)
+
 	buildext := exec.CommandContext(ctx, "pg_buildext", "updatecontrol")
 	buildext.Dir = buildDir
-	buildext.Stdout = os.Stdout
-	buildext.Stderr = os.Stderr
+	buildext.Stdout = lw
+	buildext.Stderr = lw
 
 	logger.Debug("Running pg_buildext updatecontrol", "cmd", buildext.String())
 	if err := buildext.Run(); err != nil {
@@ -331,8 +335,8 @@ func (p *DebianPackager) buildDebian(ctx context.Context, ext pgxman.Extension, 
 		fmt.Sprintf("DEB_BUILD_OPTIONS=noautodbgsym parallel=%d", runtime.NumCPU()),
 	)
 	debuild.Dir = buildDir
-	debuild.Stdout = os.Stdout
-	debuild.Stderr = os.Stderr
+	debuild.Stdout = lw
+	debuild.Stderr = lw
 
 	logger.Debug("Running debuild", "cmd", debuild.String())
 	if err := debuild.Run(); err != nil {

--- a/internal/plugin/debian/packager.go
+++ b/internal/plugin/debian/packager.go
@@ -348,7 +348,6 @@ func (p *DebianPackager) buildDebian(ctx context.Context, ext pgxman.Extension, 
 
 type extensionData struct {
 	pgxman.Extension
-	pgxman.PGVersion
 }
 
 func (e extensionData) Maintainers() string {
@@ -429,8 +428,8 @@ func concatBuildScript(scripts []pgxman.BuildScript) string {
 }
 
 type debianPackageTemplater struct {
-	ext   pgxman.Extension
-	pgVer pgxman.PGVersion
+	ext         pgxman.Extension
+	targetPGVer pgxman.PGVersion
 }
 
 func (d debianPackageTemplater) Render(content []byte, out io.Writer) error {
@@ -440,7 +439,8 @@ func (d debianPackageTemplater) Render(content []byte, out io.Writer) error {
 	}
 
 	d.ext.Name = debNormalizedName(d.ext.Name)
-	if err := t.Execute(out, extensionData{d.ext, d.pgVer}); err != nil {
+	d.ext.PGVersions = []pgxman.PGVersion{d.targetPGVer} // FIXME: hardcode to effective pg version for now
+	if err := t.Execute(out, extensionData{d.ext}); err != nil {
 		return fmt.Errorf("execute template: %w", err)
 	}
 

--- a/internal/plugin/debian/packager_test.go
+++ b/internal/plugin/debian/packager_test.go
@@ -14,10 +14,11 @@ func Test_debianPackageTemplater(t *testing.T) {
 	ext := pgxman.Extension{
 		Name:              "pgvector",
 		Maintainers:       []pgxman.Maintainer{{Name: "Owen Ou", Email: "o@hydra.so"}},
+		PGVersions:        []pgxman.PGVersion{pgxman.PGVersion14},
 		BuildDependencies: []string{"libxml2", "pgxman/multicorn"},
 		RunDependencies:   []string{"libxml2", "pgxman/multicorn"},
 	}
-	pgVer := pgxman.PGVersion13
+	targetPGVEr := pgxman.PGVersion13
 
 	cases := []struct {
 		Name        string
@@ -45,9 +46,9 @@ func Test_debianPackageTemplater(t *testing.T) {
 			WantContent: "Owen Ou <o@hydra.so>",
 		},
 		{
-			Name:        "pg version",
-			Content:     `{{ .PGVersion }}`,
-			WantContent: "13",
+			Name:        "target pg versions",
+			Content:     `{{ .PGVersions }}`,
+			WantContent: "[13]",
 		},
 	}
 
@@ -59,7 +60,7 @@ func Test_debianPackageTemplater(t *testing.T) {
 
 			buf := bytes.NewBuffer(nil)
 
-			err := debianPackageTemplater{ext, pgVer}.Render([]byte(c.Content), buf)
+			err := debianPackageTemplater{ext, targetPGVEr}.Render([]byte(c.Content), buf)
 			assert.NoError(err)
 			assert.Equal(c.WantContent, buf.String())
 		})

--- a/internal/plugin/debian/packager_test.go
+++ b/internal/plugin/debian/packager_test.go
@@ -17,6 +17,7 @@ func Test_debianPackageTemplater(t *testing.T) {
 		BuildDependencies: []string{"libxml2", "pgxman/multicorn"},
 		RunDependencies:   []string{"libxml2", "pgxman/multicorn"},
 	}
+	pgVer := pgxman.PGVersion13
 
 	cases := []struct {
 		Name        string
@@ -43,6 +44,11 @@ func Test_debianPackageTemplater(t *testing.T) {
 			Content:     `{{ .Maintainers }}`,
 			WantContent: "Owen Ou <o@hydra.so>",
 		},
+		{
+			Name:        "pg version",
+			Content:     `{{ .PGVersion }}`,
+			WantContent: "13",
+		},
 	}
 
 	for _, c := range cases {
@@ -53,7 +59,7 @@ func Test_debianPackageTemplater(t *testing.T) {
 
 			buf := bytes.NewBuffer(nil)
 
-			err := debianPackageTemplater{ext}.Render([]byte(c.Content), buf)
+			err := debianPackageTemplater{ext, pgVer}.Render([]byte(c.Content), buf)
 			assert.NoError(err)
 			assert.Equal(c.WantContent, buf.String())
 		})

--- a/internal/template/debian/debian/pgversions
+++ b/internal/template/debian/debian/pgversions
@@ -1,1 +1,3 @@
-{{ .PGVersion }}
+{{- range .PGVersions }}
+{{ . }}
+{{- end }}

--- a/internal/template/debian/debian/pgversions
+++ b/internal/template/debian/debian/pgversions
@@ -1,3 +1,1 @@
-{{- range .PGVersions }}
-{{ . }}
-{{- end }}
+{{ .PGVersion }}

--- a/internal/template/debian/script/post
+++ b/internal/template/debian/script/post
@@ -1,7 +1,0 @@
-#!/usr/bin/env bash
-
-set -eo pipefail
-
-echo "---> Running post-build script {{ .Name }} ({{ .Version }})"
-
-{{ .PostBuildScript }}

--- a/internal/template/debian/script/pre
+++ b/internal/template/debian/script/pre
@@ -1,7 +1,0 @@
-#!/usr/bin/env bash
-
-set -eo pipefail
-
-echo "---> Running pre-build script {{ .Name }} ({{ .Version }})"
-
-{{ .PreBuildScript }}

--- a/internal/template/docker/Dockerfile
+++ b/internal/template/docker/Dockerfile
@@ -9,7 +9,6 @@ ARG WORKSPACE_DIR
 
 RUN mkdir ${WORKSPACE_DIR}
 WORKDIR ${WORKSPACE_DIR}
-COPY source.tar.gz ${WORKSPACE_DIR}/source.tar.gz
 COPY extension.yaml ${WORKSPACE_DIR}/extension.yaml
 
 RUN pgxman-pack init $PGXMAN_PACK_ARGS

--- a/internal/template/docker/Dockerfile.export
+++ b/internal/template/docker/Dockerfile.export
@@ -5,11 +5,15 @@ FROM ubuntu AS merge
 ARG WORKSPACE_DIR
 
 {{- if .ExportDebianBookwormArtifacts }}
-COPY --from=debian-bookworm ${WORKSPACE_DIR}/target/*.deb  /out/debian/bookworm/
+{{- range .PGVersions }}
+COPY --from=debian-bookworm ${WORKSPACE_DIR}/target/{{ . }}/*.deb  /out/debian/bookworm/
+{{- end }}
 {{- end }}
 
 {{- if .ExportUbuntuJammyArtifacts }}
-COPY --from=ubuntu-jammy ${WORKSPACE_DIR}/target/*.deb  /out/ubuntu/jammy/
+{{- range .PGVersions }}
+COPY --from=ubuntu-jammy ${WORKSPACE_DIR}/target/{{ . }}/*.deb  /out/ubuntu/jammy/
+{{- end }}
 {{- end }}
 
 FROM ubuntu AS export

--- a/internal/template/script/embed.go
+++ b/internal/template/script/embed.go
@@ -1,0 +1,8 @@
+package script
+
+import (
+	"embed"
+)
+
+//go:embed all:*
+var FS embed.FS

--- a/internal/template/script/post
+++ b/internal/template/script/post
@@ -1,0 +1,7 @@
+#!/usr/bin/env bash
+
+set -eo pipefail
+
+echo "---> Running post-build script {{ .Name }}"
+
+{{ .PostBuildScript }}

--- a/internal/template/script/pre
+++ b/internal/template/script/pre
@@ -1,0 +1,7 @@
+#!/usr/bin/env bash
+
+set -eo pipefail
+
+echo "---> Running pre-build script {{ .Name }}"
+
+{{ .PreBuildScript }}


### PR DESCRIPTION
This PR separates Debian builds by pg versions and moves source downloads to the container in preparation for allowing for overwriting. Nothing should break although the builds might be a bit slower now because we are running `debuild` for each pg version in parallel. 