### PR TITLE
[HYD-766][HYD-765] Support overriding fields by pg versions

### DIFF
--- a/builder.go
+++ b/builder.go
@@ -87,14 +87,14 @@ func (b *dockerBuilder) Build(ctx context.Context, ext Extension) error {
 }
 
 func (b *dockerBuilder) generateDockerFile(ext Extension, dstDir string) error {
-	logger := b.logger.With(slog.String("name", ext.Name), slog.String("version", ext.Version))
+	logger := b.logger.With("name", ext.Name)
 	logger.Debug("Generating Dockerfile")
 
 	return tmpl.ExportFS(docker.FS, dockerFileTemplater{ext}, dstDir)
 }
 
 func (b *dockerBuilder) generateExtensionFile(ext Extension, dstDir string) error {
-	logger := b.logger.With(slog.String("name", ext.Name), slog.String("version", ext.Version))
+	logger := b.logger.With("name", ext.Name)
 	logger.Debug("Generating extension.yaml")
 
 	e, err := yaml.Marshal(ext)
@@ -272,13 +272,8 @@ func buildSHA(ext Extension) string {
 }
 
 func dockerDebugImage(p Platform, ext Extension) string {
-	var (
-		imagePath = strings.ReplaceAll(string(p), "_", "/")
-		///  Docker tags must match the regex [a-zA-Z0-9_.-], which allows alphanumeric characters, dots, underscores, and hyphens.
-		tag = strings.ReplaceAll(ext.Version, "+", "-")
-	)
-
-	return fmt.Sprintf("pgxman/%s/%s-debug:%s", imagePath, ext.Name, tag)
+	imagePath := strings.ReplaceAll(string(p), "_", "/")
+	return fmt.Sprintf("pgxman/%s/%s:debug", imagePath, ext.Name)
 }
 
 func dockerBakeTargets(ext Extension) []string {

--- a/extension.go
+++ b/extension.go
@@ -246,6 +246,11 @@ func (ext Extension) Validate() error {
 			err = errors.Join(err, e)
 		}
 	} else {
+		for pgv := range ext.Overrides.PGVersions {
+			if !slices.Contains(ext.PGVersions, pgv) {
+				err = errors.Join(err, fmt.Errorf("overriding PostgreSQL %s config but %q is not in `pgVersions`", pgv, pgv))
+			}
+		}
 		for pgv, effective := range ext.Effective() {
 			if e := effective.ExtensionOverridable.Validate(); e != nil {
 				err = errors.Join(err, fmt.Errorf("PostgreSQL %s config has errors:\n%w", pgv, e))

--- a/extension_test.go
+++ b/extension_test.go
@@ -58,46 +58,54 @@ func TestExtension_ParseSource(t *testing.T) {
 	}
 }
 
-func TestExtension_Effective(t *testing.T) {
+func TestExtension_Packages(t *testing.T) {
 	cases := []struct {
-		Name      string
-		Ext       Extension
-		Effective map[PGVersion]Extension
+		Name         string
+		Ext          Extension
+		WantPackages []ExtensionPackage
 	}{
 		{
 			Name: "no overrides",
 			Ext: Extension{
-				Name:       "pg_stat_statements",
-				PGVersions: []PGVersion{PGVersion15, PGVersion16},
+				ExtensionCommon: ExtensionCommon{
+					Name: "pg_stat_statements",
+				},
 				ExtensionOverridable: ExtensionOverridable{
 					Source: "source",
 				},
+				PGVersions: []PGVersion{PGVersion15, PGVersion16},
 			},
-			Effective: map[PGVersion]Extension{
-				PGVersion15: {
-					Name:       "pg_stat_statements",
-					PGVersions: []PGVersion{PGVersion15},
+			WantPackages: []ExtensionPackage{
+				{
+					ExtensionCommon: ExtensionCommon{
+						Name: "pg_stat_statements",
+					},
 					ExtensionOverridable: ExtensionOverridable{
 						Source: "source",
 					},
+					PGVersion: PGVersion15,
 				},
-				PGVersion16: {
-					Name:       "pg_stat_statements",
-					PGVersions: []PGVersion{PGVersion16},
+				{
+					ExtensionCommon: ExtensionCommon{
+						Name: "pg_stat_statements",
+					},
 					ExtensionOverridable: ExtensionOverridable{
 						Source: "source",
 					},
+					PGVersion: PGVersion16,
 				},
 			},
 		},
 		{
 			Name: "have overrides",
 			Ext: Extension{
-				Name:       "pg_stat_statements",
-				PGVersions: []PGVersion{PGVersion15, PGVersion16},
+				ExtensionCommon: ExtensionCommon{
+					Name: "pg_stat_statements",
+				},
 				ExtensionOverridable: ExtensionOverridable{
 					Source: "source",
 				},
+				PGVersions: []PGVersion{PGVersion15, PGVersion16},
 				Overrides: &ExtensionOverrides{
 					PGVersions: map[PGVersion]ExtensionOverridable{
 						PGVersion16: {
@@ -109,21 +117,25 @@ func TestExtension_Effective(t *testing.T) {
 					},
 				},
 			},
-			Effective: map[PGVersion]Extension{
-				PGVersion15: {
-					Name:       "pg_stat_statements",
-					PGVersions: []PGVersion{PGVersion15},
+			WantPackages: []ExtensionPackage{
+				{
+					ExtensionCommon: ExtensionCommon{
+						Name: "pg_stat_statements",
+					},
 					ExtensionOverridable: ExtensionOverridable{
 						Source:  "source",
 						Version: "15.5.0",
 					},
+					PGVersion: PGVersion15,
 				},
-				PGVersion16: {
-					Name:       "pg_stat_statements",
-					PGVersions: []PGVersion{PGVersion16},
+				{
+					ExtensionCommon: ExtensionCommon{
+						Name: "pg_stat_statements",
+					},
 					ExtensionOverridable: ExtensionOverridable{
 						Source: "source16",
 					},
+					PGVersion: PGVersion16,
 				},
 			},
 		},
@@ -136,7 +148,7 @@ func TestExtension_Effective(t *testing.T) {
 			t.Parallel()
 
 			assert := assert.New(t)
-			assert.Equal(c.Effective, c.Ext.Effective())
+			assert.Equal(c.WantPackages, c.Ext.Packages())
 		})
 	}
 }

--- a/extension_test.go
+++ b/extension_test.go
@@ -18,21 +18,27 @@ func TestExtension_ParseSource(t *testing.T) {
 		{
 			name: "http source",
 			ext: Extension{
-				Source: "http://example.com/test.tar.gz",
+				ExtensionOverridable: ExtensionOverridable{
+					Source: "http://example.com/test.tar.gz",
+				},
 			},
 			wantExt: &httpExtensionSource{URL: "http://example.com/test.tar.gz"},
 		},
 		{
 			name: "file source",
 			ext: Extension{
-				Source: "file:///tmp/test.tar.gz",
+				ExtensionOverridable: ExtensionOverridable{
+					Source: "file:///tmp/test.tar.gz",
+				},
 			},
 			wantExt: &fileExtensionSource{Dir: "/tmp/test.tar.gz"},
 		},
 		{
 			name: "invalid source",
 			ext: Extension{
-				Source: "ftp://example.com/test.tar.gz",
+				ExtensionOverridable: ExtensionOverridable{
+					Source: "ftp://example.com/test.tar.gz",
+				},
 			},
 			wantErr: true,
 		},
@@ -50,4 +56,114 @@ func TestExtension_ParseSource(t *testing.T) {
 			assert.Equal(tt.wantExt, gotExt)
 		})
 	}
+}
+
+func TestExtension_Effective(t *testing.T) {
+	cases := []struct {
+		Name      string
+		Ext       Extension
+		Effective map[PGVersion]Extension
+	}{
+		{
+			Name: "no overrides",
+			Ext: Extension{
+				Name:       "pg_stat_statements",
+				PGVersions: []PGVersion{PGVersion15, PGVersion16},
+				ExtensionOverridable: ExtensionOverridable{
+					Source: "source",
+				},
+			},
+			Effective: map[PGVersion]Extension{
+				PGVersion15: {
+					Name:       "pg_stat_statements",
+					PGVersions: []PGVersion{PGVersion15},
+					ExtensionOverridable: ExtensionOverridable{
+						Source: "source",
+					},
+				},
+				PGVersion16: {
+					Name:       "pg_stat_statements",
+					PGVersions: []PGVersion{PGVersion16},
+					ExtensionOverridable: ExtensionOverridable{
+						Source: "source",
+					},
+				},
+			},
+		},
+		{
+			Name: "have overrides",
+			Ext: Extension{
+				Name:       "pg_stat_statements",
+				PGVersions: []PGVersion{PGVersion15, PGVersion16},
+				ExtensionOverridable: ExtensionOverridable{
+					Source: "source",
+				},
+				Overrides: &ExtensionOverrides{
+					PGVersions: map[PGVersion]ExtensionOverridable{
+						PGVersion16: {
+							Source: "source16",
+						},
+						PGVersion15: {
+							Version: "15.5.0",
+						},
+					},
+				},
+			},
+			Effective: map[PGVersion]Extension{
+				PGVersion15: {
+					Name:       "pg_stat_statements",
+					PGVersions: []PGVersion{PGVersion15},
+					ExtensionOverridable: ExtensionOverridable{
+						Source:  "source",
+						Version: "15.5.0",
+					},
+				},
+				PGVersion16: {
+					Name:       "pg_stat_statements",
+					PGVersions: []PGVersion{PGVersion16},
+					ExtensionOverridable: ExtensionOverridable{
+						Source: "source16",
+					},
+				},
+			},
+		},
+	}
+
+	for _, c := range cases {
+		c := c
+
+		t.Run(c.Name, func(t *testing.T) {
+			t.Parallel()
+
+			assert := assert.New(t)
+			assert.Equal(c.Effective, c.Ext.Effective())
+		})
+	}
+}
+
+func TestExtension_Validate(t *testing.T) {
+	assert := assert.New(t)
+
+	ext := Extension{
+		PGVersions: []PGVersion{PGVersion16},
+	}
+	err := ext.Validate()
+	assert.Error(err)
+	assert.NotContains(err.Error(), "PostgreSQL 16 config has errors")
+	assert.Contains(err.Error(), "version is required")
+
+	ext = Extension{
+		PGVersions: []PGVersion{PGVersion16},
+		Overrides: &ExtensionOverrides{
+			PGVersions: map[PGVersion]ExtensionOverridable{
+				PGVersion16: {
+					Version: "1.2.3",
+				},
+			},
+		},
+	}
+	err = ext.Validate()
+	assert.Error(err)
+	assert.Contains(err.Error(), "PostgreSQL 16 config has errors")
+	assert.NotContains(err.Error(), "version is required")
 }

--- a/extension_test.go
+++ b/extension_test.go
@@ -166,4 +166,18 @@ func TestExtension_Validate(t *testing.T) {
 	assert.Error(err)
 	assert.Contains(err.Error(), "PostgreSQL 16 config has errors")
 	assert.NotContains(err.Error(), "version is required")
+
+	ext = Extension{
+		PGVersions: []PGVersion{PGVersion15},
+		Overrides: &ExtensionOverrides{
+			PGVersions: map[PGVersion]ExtensionOverridable{
+				PGVersion16: {
+					Version: "1.2.3",
+				},
+			},
+		},
+	}
+	err = ext.Validate()
+	assert.Error(err)
+	assert.Contains(err.Error(), "overriding PostgreSQL 16 config but \"16\" is not in `pgVersions`")
 }

--- a/internal/cmd/pgxman/init.go
+++ b/internal/cmd/pgxman/init.go
@@ -35,18 +35,20 @@ func runInit(c *cobra.Command, args []string) error {
 	ext := &pgxman.Extension{
 		APIVersion: pgxman.DefaultExtensionAPIVersion,
 		Name:       "my-pg-extension",
-		Build: pgxman.Build{
-			Main: []pgxman.BuildScript{
-				{
-					Name: "my build step",
-					Run: `# Uncomment to write the build script for the extension.
+		ExtensionOverridable: pgxman.ExtensionOverridable{
+			Build: pgxman.Build{
+				Main: []pgxman.BuildScript{
+					{
+						Name: "my build step",
+						Run: `# Uncomment to write the build script for the extension.
 # The built extension must be installed in the $DESTDIR directory.
 # See https://docs.pgxman.com/spec/buildkit#build for details.
 `,
+					},
 				},
 			},
+			Version: "1.0.0",
 		},
-		Version: "1.0.0",
 		License: "PostgreSQL",
 		Maintainers: []pgxman.Maintainer{
 			{

--- a/internal/cmd/pgxman/init.go
+++ b/internal/cmd/pgxman/init.go
@@ -34,7 +34,16 @@ func runInit(c *cobra.Command, args []string) error {
 
 	ext := &pgxman.Extension{
 		APIVersion: pgxman.DefaultExtensionAPIVersion,
-		Name:       "my-pg-extension",
+		ExtensionCommon: pgxman.ExtensionCommon{
+			Name:    "my-pg-extension",
+			License: "PostgreSQL",
+			Maintainers: []pgxman.Maintainer{
+				{
+					Name:  user.Name,
+					Email: user.Username + "@localhost",
+				},
+			},
+		},
 		ExtensionOverridable: pgxman.ExtensionOverridable{
 			Build: pgxman.Build{
 				Main: []pgxman.BuildScript{
@@ -48,13 +57,6 @@ func runInit(c *cobra.Command, args []string) error {
 				},
 			},
 			Version: "1.0.0",
-		},
-		License: "PostgreSQL",
-		Maintainers: []pgxman.Maintainer{
-			{
-				Name:  user.Name,
-				Email: user.Username + "@localhost",
-			},
 		},
 		PGVersions: pgxman.SupportedPGVersions,
 	}

--- a/internal/e2etest/builder_test.go
+++ b/internal/e2etest/builder_test.go
@@ -23,6 +23,14 @@ func TestBuilder(t *testing.T) {
 	ext.Source = "https://github.com/pgvector/pgvector/archive/refs/tags/v0.5.0.tar.gz"
 	ext.Repository = "https://github.com/pgvector/pgvector"
 	ext.Version = "0.5.0"
+	ext.PGVersions = pgxman.SupportedPGVersions
+	ext.Overrides = &pgxman.ExtensionOverrides{
+		PGVersions: map[pgxman.PGVersion]pgxman.ExtensionOverridable{
+			pgxman.PGVersion16: {
+				Version: "16.5.0",
+			},
+		},
+	}
 	ext.License = "PostgreSQL"
 	ext.RunDependencies = []string{"libcurl4-openssl-dev"}
 	ext.Builders = &pgxman.ExtensionBuilders{
@@ -80,7 +88,6 @@ echo $PGXS
 		},
 	}
 
-	ext.PGVersions = pgxman.SupportedPGVersions
 	ext.Maintainers = []pgxman.Maintainer{
 		{
 			Name:  "Owen Ou",
@@ -106,6 +113,9 @@ echo $PGXS
 	matches, err := filepathx.WalkMatch(extdir, "*.deb")
 	assert.NoError(err)
 	assert.Len(matches, 4*2) // 13, 14, 15, 16 for current arch only for debian:bookworm & ubuntu:jammy
+	// verify overriden version
+	assert.Contains(matches, filepath.Join(extdir, fmt.Sprintf("out/debian/bookworm/postgresql-16-pgxman-pgvector_16.5.0_%s.deb", runtime.GOARCH)))
+	assert.Contains(matches, filepath.Join(extdir, fmt.Sprintf("out/ubuntu/jammy//postgresql-16-pgxman-pgvector_16.5.0_%s.deb", runtime.GOARCH)))
 
 	for _, match := range matches {
 		var (

--- a/internal/plugin/debian/packager.go
+++ b/internal/plugin/debian/packager.go
@@ -70,8 +70,8 @@ func (p *DebianPackager) Init(ctx context.Context, ext pgxman.Extension, opts pg
 		return fmt.Errorf("write pre/post scripts: %w", err)
 	}
 
-	for pgVer, ext := range ext.Effective() {
-		if err := p.prepareBuildDir(ctx, opts, ext, pgVer); err != nil {
+	for _, pkg := range ext.Packages() {
+		if err := p.prepareBuildDir(ctx, opts, pkg); err != nil {
 			return fmt.Errorf("prepare build dir: %w", err)
 		}
 	}
@@ -107,12 +107,11 @@ func (p *DebianPackager) Main(ctx context.Context, ext pgxman.Extension, opts pg
 	}
 
 	g, ctx := errgroup.WithContext(ctx)
-	for pgVer, ext := range ext.Effective() {
-		pgVer := pgVer
-		ext := ext
+	for _, pkg := range ext.Packages() {
+		pkg := pkg
 
 		g.Go(func() error {
-			if err := p.buildDebian(ctx, ext, pgVer, p.targetDebianBuildDir(opts, pgVer)); err != nil {
+			if err := p.buildDebian(ctx, pkg, p.targetDebianBuildDir(opts, pkg.PGVersion)); err != nil {
 				return fmt.Errorf("debian build: %w", err)
 			}
 
@@ -123,29 +122,29 @@ func (p *DebianPackager) Main(ctx context.Context, ext pgxman.Extension, opts pg
 	return g.Wait()
 }
 
-func (p *DebianPackager) prepareBuildDir(ctx context.Context, opts pgxman.PackagerOptions, ext pgxman.Extension, pgVer pgxman.PGVersion) error {
-	targetPgVerDir := p.targetPgVerDir(opts, pgVer)
+func (p *DebianPackager) prepareBuildDir(ctx context.Context, opts pgxman.PackagerOptions, pkg pgxman.ExtensionPackage) error {
+	targetPgVerDir := p.targetPgVerDir(opts, pkg.PGVersion)
 	if err := os.MkdirAll(targetPgVerDir, 0755); err != nil {
 		return fmt.Errorf("mkdir: %w", err)
 	}
 
-	debianBuildDir := p.targetDebianBuildDir(opts, pgVer)
+	debianBuildDir := p.targetDebianBuildDir(opts, pkg.PGVersion)
 	if err := os.MkdirAll(debianBuildDir, 0755); err != nil {
 		return fmt.Errorf("mkdir: %w", err)
 	}
 
-	p.Logger.Debug("Preparing build dir", "target", targetPgVerDir, "name", ext.Name, "pgVer", pgVer)
+	p.Logger.Debug("Preparing build dir", "target", targetPgVerDir, "name", pkg.Name, "pgVer", pkg.PGVersion)
 
-	sourceFile, err := p.downloadSource(ext, targetPgVerDir)
+	sourceFile, err := p.downloadSource(pkg, targetPgVerDir)
 	if err != nil {
-		return fmt.Errorf("download source %s: %w", ext.Source, err)
+		return fmt.Errorf("download source %s: %w", pkg.Source, err)
 	}
 
 	if err := p.unarchiveSource(ctx, sourceFile, debianBuildDir); err != nil {
 		return fmt.Errorf("unarchive source: %w", err)
 	}
 
-	if err := p.generateDebianTemplate(ext, debianBuildDir); err != nil {
+	if err := p.generateDebianTemplate(pkg, debianBuildDir); err != nil {
 		return fmt.Errorf("generate debian template: %w", err)
 	}
 
@@ -175,7 +174,7 @@ func (p *DebianPackager) targetDebianBuildDir(opts pgxman.PackagerOptions, pgVer
 	return filepath.Join(p.targetPgVerDir(opts, pgVer), "debian_build")
 }
 
-func (p *DebianPackager) downloadSource(ext pgxman.Extension, targetDir string) (string, error) {
+func (p *DebianPackager) downloadSource(ext pgxman.ExtensionPackage, targetDir string) (string, error) {
 	logger := p.Logger.With(slog.String("source", ext.Source))
 	logger.Info("Downloading source")
 
@@ -231,7 +230,7 @@ func (p *DebianPackager) unarchiveSource(ctx context.Context, sourceFile, buildD
 	return c.Unarchive(sourceFile, sourceDir)
 }
 
-func (p *DebianPackager) generateDebianTemplate(ext pgxman.Extension, debianBuildDir string) error {
+func (p *DebianPackager) generateDebianTemplate(ext pgxman.ExtensionPackage, debianBuildDir string) error {
 	logger := p.Logger.With("name", ext.Name, "debian-build-dir", debianBuildDir)
 	logger.Info("Generating debian template")
 
@@ -307,9 +306,9 @@ func (p *DebianPackager) runScript(ctx context.Context, file string) error {
 	return nil
 }
 
-func (p *DebianPackager) buildDebian(ctx context.Context, ext pgxman.Extension, pgVer pgxman.PGVersion, buildDir string) error {
-	logger := p.Logger.WithGroup(string(pgVer))
-	logger = logger.With("name", ext.Name, "version", ext.Version, "build-dir", buildDir)
+func (p *DebianPackager) buildDebian(ctx context.Context, pkg pgxman.ExtensionPackage, buildDir string) error {
+	logger := p.Logger.WithGroup(string(pkg.PGVersion))
+	logger = logger.With("name", pkg.Name, "version", pkg.Version, "build-dir", buildDir)
 	logger.Info("Building debian package")
 
 	lw := logger.Writer(slog.LevelDebug)
@@ -348,12 +347,12 @@ func (p *DebianPackager) buildDebian(ctx context.Context, ext pgxman.Extension, 
 }
 
 type extensionData struct {
-	pgxman.Extension
+	pgxman.ExtensionPackage
 }
 
 func (e extensionData) Maintainers() string {
 	var maintainers []string
-	for _, m := range e.Extension.Maintainers {
+	for _, m := range e.ExtensionPackage.Maintainers {
 		maintainers = append(maintainers, fmt.Sprintf("%s <%s>", m.Name, m.Email))
 	}
 
@@ -366,8 +365,8 @@ func (e extensionData) BuildDeps() string {
 		"postgresql-server-dev-all (>= 158~)",
 	}
 
-	deps := e.Extension.BuildDependencies
-	if builders := e.Extension.Builders; builders != nil {
+	deps := e.BuildDependencies
+	if builders := e.Builders; builders != nil {
 		builder := builders.Current()
 		if len(builder.BuildDependencies) != 0 {
 			deps = builder.BuildDependencies
@@ -383,8 +382,8 @@ func (e extensionData) Deps() string {
 		"${misc:Depends}",
 	}
 
-	deps := e.Extension.RunDependencies
-	if builders := e.Extension.Builders; builders != nil {
+	deps := e.RunDependencies
+	if builders := e.Builders; builders != nil {
 		builder := builders.Current()
 		if len(builder.RunDependencies) != 0 {
 			deps = builder.RunDependencies
@@ -395,7 +394,7 @@ func (e extensionData) Deps() string {
 }
 
 func (e extensionData) MainBuildScript() string {
-	return concatBuildScript(e.Extension.Build.Main)
+	return concatBuildScript(e.Build.Main)
 }
 
 func (e extensionData) TimeNow() string {
@@ -429,7 +428,7 @@ func concatBuildScript(scripts []pgxman.BuildScript) string {
 }
 
 type debianPackageTemplater struct {
-	ext pgxman.Extension
+	ext pgxman.ExtensionPackage
 }
 
 func (d debianPackageTemplater) Render(content []byte, out io.Writer) error {

--- a/internal/plugin/debian/packager_test.go
+++ b/internal/plugin/debian/packager_test.go
@@ -11,14 +11,16 @@ import (
 func Test_debianPackageTemplater(t *testing.T) {
 	assert := assert.New(t)
 
-	ext := pgxman.Extension{
-		Name:        "pgvector",
-		Maintainers: []pgxman.Maintainer{{Name: "Owen Ou", Email: "o@hydra.so"}},
-		PGVersions:  []pgxman.PGVersion{pgxman.PGVersion14},
+	ext := pgxman.ExtensionPackage{
+		ExtensionCommon: pgxman.ExtensionCommon{
+			Name:        "pgvector",
+			Maintainers: []pgxman.Maintainer{{Name: "Owen Ou", Email: "o@hydra.so"}},
+		},
 		ExtensionOverridable: pgxman.ExtensionOverridable{
 			BuildDependencies: []string{"libxml2", "pgxman/multicorn"},
 			RunDependencies:   []string{"libxml2", "pgxman/multicorn"},
 		},
+		PGVersion: pgxman.PGVersion14,
 	}
 
 	cases := []struct {
@@ -47,9 +49,9 @@ func Test_debianPackageTemplater(t *testing.T) {
 			WantContent: "Owen Ou <o@hydra.so>",
 		},
 		{
-			Name:        "pg versions",
-			Content:     `{{ .PGVersions }}`,
-			WantContent: "[14]",
+			Name:        "pg version",
+			Content:     `{{ .PGVersion }}`,
+			WantContent: "14",
 		},
 	}
 

--- a/internal/plugin/debian/packager_test.go
+++ b/internal/plugin/debian/packager_test.go
@@ -20,7 +20,6 @@ func Test_debianPackageTemplater(t *testing.T) {
 			RunDependencies:   []string{"libxml2", "pgxman/multicorn"},
 		},
 	}
-	targetPGVEr := pgxman.PGVersion13
 
 	cases := []struct {
 		Name        string
@@ -48,9 +47,9 @@ func Test_debianPackageTemplater(t *testing.T) {
 			WantContent: "Owen Ou <o@hydra.so>",
 		},
 		{
-			Name:        "target pg versions",
+			Name:        "pg versions",
 			Content:     `{{ .PGVersions }}`,
-			WantContent: "[13]",
+			WantContent: "[14]",
 		},
 	}
 
@@ -62,7 +61,7 @@ func Test_debianPackageTemplater(t *testing.T) {
 
 			buf := bytes.NewBuffer(nil)
 
-			err := debianPackageTemplater{ext, targetPGVEr}.Render([]byte(c.Content), buf)
+			err := debianPackageTemplater{ext}.Render([]byte(c.Content), buf)
 			assert.NoError(err)
 			assert.Equal(c.WantContent, buf.String())
 		})

--- a/internal/plugin/debian/packager_test.go
+++ b/internal/plugin/debian/packager_test.go
@@ -12,11 +12,13 @@ func Test_debianPackageTemplater(t *testing.T) {
 	assert := assert.New(t)
 
 	ext := pgxman.Extension{
-		Name:              "pgvector",
-		Maintainers:       []pgxman.Maintainer{{Name: "Owen Ou", Email: "o@hydra.so"}},
-		PGVersions:        []pgxman.PGVersion{pgxman.PGVersion14},
-		BuildDependencies: []string{"libxml2", "pgxman/multicorn"},
-		RunDependencies:   []string{"libxml2", "pgxman/multicorn"},
+		Name:        "pgvector",
+		Maintainers: []pgxman.Maintainer{{Name: "Owen Ou", Email: "o@hydra.so"}},
+		PGVersions:  []pgxman.PGVersion{pgxman.PGVersion14},
+		ExtensionOverridable: pgxman.ExtensionOverridable{
+			BuildDependencies: []string{"libxml2", "pgxman/multicorn"},
+			RunDependencies:   []string{"libxml2", "pgxman/multicorn"},
+		},
 	}
 	targetPGVEr := pgxman.PGVersion13
 

--- a/internal/template/debian/debian/pgversions
+++ b/internal/template/debian/debian/pgversions
@@ -1,3 +1,1 @@
-{{- range .PGVersions }}
-{{ . }}
-{{- end }}
+{{ .PGVersion }}


### PR DESCRIPTION
Given a buildkit manifest like the following:

```yaml
apiVersion: v1
build:
  main:
    - name: build step
      run: |
        make
        DESTDIR=${DESTDIR} make install
keywords:
  - hint
  - plan
  - index
maintainers:
  - email: jd@hydra.so
    name: Jonathan Dance
name: pg_hint_plan
pgVersions:
  - "16"
  - "15"
overrides:
  pgVersions:
    "16":
      source: https://github.com/ossc-db/pg_hint_plan/archive/refs/tags/REL16_1_6_0.tar.gz
      version: 1.6.0-1
    "15":
      source: https://github.com/ossc-db/pg_hint_plan/archive/refs/tags/REL15_1_5_0.tar.gz
      version: 1.5.0-1
repository: https://github.com/ossc-db/pg_hint_plan
license: PostgreSQL
homepage: https://github.com/ossc-db/pg_hint_plan
description: Give PostgreSQL ability to manually force some decisions in execution plans.
```

`pgxman build` allows overriding fields for a particular pg version. The build output of the above manifest is as followed:

```
$ tree out
out
├── debian
│   └── bookworm
│       ├── postgresql-15-pgxman-pg-hint-plan_1.5.0-1_arm64.deb
│       └── postgresql-16-pgxman-pg-hint-plan_1.6.0-1_arm64.deb
└── ubuntu
    └── jammy
        ├── postgresql-15-pgxman-pg-hint-plan_1.5.0-1_arm64.deb
        └── postgresql-16-pgxman-pg-hint-plan_1.6.0-1_arm64.deb

5 directories, 4 files
```

Docs update will be in another PR.