### PR TITLE
Allow customizing parallel builds

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -132,6 +132,8 @@ jobs:
           go-version-file: go.mod
           check-latest: true
       - name: Run tests
+        env:
+          HOMEBREW_GITHUB_API_TOKEN: ${{ secrets.GITHUB_TOKEN }}
         run: |
           RUNNER_TARGET=runner-postgres-15 RUNNER_POSTGRES_15_IMAGE=ghcr.io/pgxman/runner/postgres/15:dev make docker_load_runner
           GORELEASER_GITHUB_RELEASE_DOWNLOAD_URL=file://$(pwd)/dist make tools goreleaser

--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -96,6 +96,8 @@ jobs:
         run: |
           ./script/start-colima-macos
       - name: Run tests
+        env:
+          HOMEBREW_GITHUB_API_TOKEN: ${{ secrets.GITHUB_TOKEN }}
         run: |
           ./install.sh
           pgxman install pgvector postgis parquet_s3_fdw --debug

--- a/builder.go
+++ b/builder.go
@@ -29,6 +29,7 @@ type BuilderOptions struct {
 	ExtDir    string
 	CacheFrom []string
 	CacheTo   []string
+	Parallel  int
 	Debug     bool
 	NoCache   bool
 }
@@ -206,6 +207,8 @@ func (b *dockerBuilder) dockerBakeArgs(ext Extension, targets []string, extraArg
 			fmt.Sprintf("%s.args.BUILD_IMAGE=%s", bakeTargetName, builder.Image),
 			"--set",
 			fmt.Sprintf("%s.args.BUILD_SHA=%s", bakeTargetName, sha),
+			"--set",
+			fmt.Sprintf("%s.args.PARALLEL=%d", bakeTargetName, b.Parallel),
 			"--set",
 			fmt.Sprintf("%s.args.WORKSPACE_DIR=%s", bakeTargetName, buildWorkspaceDir),
 		)

--- a/internal/cmd/pgxmanpack/root.go
+++ b/internal/cmd/pgxmanpack/root.go
@@ -1,6 +1,7 @@
 package pgxmanpack
 
 import (
+	"fmt"
 	"os"
 	"path/filepath"
 
@@ -14,7 +15,8 @@ import (
 )
 
 var (
-	flagDebug bool
+	flagDebug    bool
+	flagParallel int
 
 	extension    pgxman.Extension
 	packager     pgxman.Packager
@@ -29,6 +31,10 @@ func Execute() error {
 		PersistentPreRunE: func(cmd *cobra.Command, args []string) error {
 			if flagDebug {
 				log.SetLevel(slog.LevelDebug)
+			}
+
+			if flagParallel < 1 {
+				return fmt.Errorf("invalid parallel value: %d", flagParallel)
 			}
 
 			var err error
@@ -48,8 +54,9 @@ func Execute() error {
 			}
 
 			packagerOpts = pgxman.PackagerOptions{
-				WorkDir: workDir,
-				Debug:   flagDebug,
+				WorkDir:  workDir,
+				Parallel: flagParallel,
+				Debug:    flagDebug,
 			}
 
 			return nil
@@ -76,6 +83,7 @@ func Execute() error {
 	}
 
 	root.PersistentFlags().BoolVar(&flagDebug, "debug", os.Getenv("DEBUG") != "", "enable debug logging")
+	root.PersistentFlags().IntVar(&flagParallel, "parallel", 2, "number of parallel builds to run")
 
 	root.AddCommand(newInitCmd())
 	root.AddCommand(newPreCmd())

--- a/internal/e2etest/builder_test.go
+++ b/internal/e2etest/builder_test.go
@@ -98,8 +98,9 @@ echo $PGXS
 	extdir := t.TempDir()
 	builder := pgxman.NewBuilder(
 		pgxman.BuilderOptions{
-			ExtDir: extdir,
-			Debug:  true,
+			ExtDir:   extdir,
+			Parallel: 1,
+			Debug:    true,
 			// Caching for CI.
 			// They are ignored when not running in GitHub Actions.
 			CacheFrom: []string{"type=gha"},

--- a/internal/template/docker/Dockerfile
+++ b/internal/template/docker/Dockerfile
@@ -4,6 +4,7 @@ ARG BUILD_IMAGE
 FROM $BUILD_IMAGE as build
 
 ARG BUILD_SHA
+ARG PARALLEL=""
 ARG PGXMAN_PACK_ARGS=""
 ARG WORKSPACE_DIR
 
@@ -13,5 +14,5 @@ COPY extension.yaml ${WORKSPACE_DIR}/extension.yaml
 
 RUN pgxman-pack init $PGXMAN_PACK_ARGS
 RUN pgxman-pack pre $PGXMAN_PACK_ARGS
-RUN pgxman-pack main $PGXMAN_PACK_ARGS
+RUN pgxman-pack main --parallel $PARALLEL $PGXMAN_PACK_ARGS
 RUN pgxman-pack post $PGXMAN_PACK_ARGS

--- a/packager.go
+++ b/packager.go
@@ -5,8 +5,9 @@ import (
 )
 
 type PackagerOptions struct {
-	WorkDir string
-	Debug   bool
+	WorkDir  string
+	Parallel int
+	Debug    bool
 }
 
 type Packager interface {


### PR DESCRIPTION
Allow customizing parallel builds. [Some Rust builds](https://github.com/pgxman/buildkit/pull/76#issuecomment-1912896298) are resource intensive and they do not fit well to run in parallel. This adds `--parallel N` to allow customizing number of parallel builds.