### PR TITLE
[HYD-777] Fix bug that disallows overriding a pg version

### DIFF
--- a/io_test.go
+++ b/io_test.go
@@ -6,33 +6,128 @@ import (
 	"github.com/stretchr/testify/assert"
 )
 
-func Test_overrideYamlFields(t *testing.T) {
-	assert := assert.New(t)
-
-	b, err := overrideYamlFields([]byte(`apiVersion: v1
-buildImage: foo
-maintainers:
-- name: foo
-pgVersions:
-- "10"
-- "11"
-- "12"
-`), map[string]any{
-		"buildImage": "bar",
-		"maintainers": []map[string]any{
-			{
-				"name": "Owen",
+func Test_overrideExtension(t *testing.T) {
+	cases := []struct {
+		Name      string
+		Ext       Extension
+		Overrides map[string]any
+		WantExt   Extension
+	}{
+		{
+			Name: "no overrides",
+			Ext: Extension{
+				ExtensionCommon: ExtensionCommon{
+					Name: "pgvector",
+					Maintainers: []Maintainer{
+						{
+							Name: "foo",
+						},
+					},
+				},
+				PGVersions: []PGVersion{"13", "14", "15"},
+				Overrides: &ExtensionOverrides{
+					PGVersions: map[PGVersion]ExtensionOverridable{
+						PGVersion13: {
+							Source: "source13",
+						},
+						PGVersion14: {
+							Source: "source14",
+						},
+						PGVersion15: {
+							Source: "source15",
+						},
+					},
+				},
+			},
+			Overrides: nil,
+			WantExt: Extension{
+				ExtensionCommon: ExtensionCommon{
+					Name: "pgvector",
+					Maintainers: []Maintainer{
+						{
+							Name: "foo",
+						},
+					},
+				},
+				PGVersions: []PGVersion{"13", "14", "15"},
+				Overrides: &ExtensionOverrides{
+					PGVersions: map[PGVersion]ExtensionOverridable{
+						PGVersion13: {
+							Source: "source13",
+						},
+						PGVersion14: {
+							Source: "source14",
+						},
+						PGVersion15: {
+							Source: "source15",
+						},
+					},
+				},
 			},
 		},
-		"pgVersions": []string{"11", "12"},
-	})
-	assert.NoError(err)
-	assert.Equal(`apiVersion: v1
-buildImage: bar
-maintainers:
-- name: Owen
-pgVersions:
-- "11"
-- "12"
-`, string(b))
+		{
+			Name: "override pg version",
+			Ext: Extension{
+				ExtensionCommon: ExtensionCommon{
+					Name: "pgvector",
+					Maintainers: []Maintainer{
+						{
+							Name: "foo",
+						},
+					},
+				},
+				PGVersions: []PGVersion{"13", "14", "15"},
+				Overrides: &ExtensionOverrides{
+					PGVersions: map[PGVersion]ExtensionOverridable{
+						PGVersion13: {
+							Source: "source13",
+						},
+						PGVersion14: {
+							Source: "source14",
+						},
+						PGVersion15: {
+							Source: "source15",
+						},
+					},
+				},
+			},
+			Overrides: map[string]any{
+				"maintainers": []map[string]any{
+					{
+						"name": "Owen",
+					},
+				},
+				"pgVersions": []string{"13"},
+			},
+			WantExt: Extension{
+				ExtensionCommon: ExtensionCommon{
+					Name: "pgvector",
+					Maintainers: []Maintainer{
+						{
+							Name: "Owen",
+						},
+					},
+				},
+				PGVersions: []PGVersion{"13"},
+				Overrides: &ExtensionOverrides{
+					PGVersions: map[PGVersion]ExtensionOverridable{
+						PGVersion13: {
+							Source: "source13",
+						},
+					},
+				},
+			},
+		},
+	}
+
+	for _, c := range cases {
+		c := c
+		t.Run(c.Name, func(t *testing.T) {
+			assert := assert.New(t)
+
+			gotExt, err := overrideExtension(c.Ext, c.Overrides)
+			assert.NoError(err)
+			assert.Equal(c.WantExt, gotExt)
+		})
+	}
 }


### PR DESCRIPTION
Fix the bug that disallows overriding a pg version. This is a miss case after introducing `overrides`.


Ref: https://github.com/pgxman/buildkit/actions/runs/7716922227/job/21034865453#step:7:14