### PR TITLE
Bring back locale fix in runner & builder image

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -61,6 +61,16 @@ jobs:
         ports:
           - 5000:5000
     steps:
+      - name: Free Disk Space (Ubuntu)
+        uses: jlumbroso/free-disk-space@main
+        with:
+          tool-cache: false
+          android: true
+          dotnet: true
+          haskell: true
+          large-packages: false
+          docker-images: false
+          swap-storage: false
       - uses: actions/checkout@v4
       - uses: actions/setup-go@v5
         with:

--- a/dockerfiles/builder/Dockerfile.debian
+++ b/dockerfiles/builder/Dockerfile.debian
@@ -51,6 +51,12 @@ RUN set -eux; \
     ; \
     apt-get clean
 
+RUN set -eux; \
+    locale-gen en_US.UTF-8; \
+    echo "LC_ALL=en_US.UTF-8" >> /etc/environment; \
+    echo "en_US.UTF-8 UTF-8" >> /etc/locale.gen; \
+    echo "LANG=en_US.UTF-8" > /etc/locale.conf
+
 # rustup
 RUN curl --proto '=https' --tlsv1.2 -sSf https://sh.rustup.rs | sh -s -- -y --no-modify-path --profile minimal
 ENV PATH=/root/.cargo/bin:$PATH

--- a/dockerfiles/runner/Dockerfile.postgres
+++ b/dockerfiles/runner/Dockerfile.postgres
@@ -12,4 +12,10 @@ RUN set -eux; \
     ; \
     apt-get clean
 
+RUN set -eux; \
+    locale-gen en_US.UTF-8; \
+    echo "LC_ALL=en_US.UTF-8" >> /etc/environment; \
+    echo "en_US.UTF-8 UTF-8" >> /etc/locale.gen; \
+    echo "LANG=en_US.UTF-8" > /etc/locale.conf
+
 COPY --from=pgxman /go/bin/* /usr/local/bin/

--- a/internal/cmd/pgxman/container.go
+++ b/internal/cmd/pgxman/container.go
@@ -144,7 +144,7 @@ func runContainerInstall(upgrade bool) func(c *cobra.Command, args []string) err
 		fmt.Printf("%s extensions in a container for PostgreSQL %s...\n", action, flagContainerInstallPGVersion)
 		for _, ext := range exts {
 			var err error
-			info, err = installInContainer(cmd.Context(), c, ext)
+			info, err = installInContainer(cmd.Context(), c, ext, flagDebug)
 			if err != nil {
 				return err
 			}
@@ -221,7 +221,7 @@ func runContainerTeardown(cmd *cobra.Command, args []string) error {
 	return nil
 }
 
-func installInContainer(ctx context.Context, c *container.Container, ext pgxman.InstallExtension) (*container.ContainerInfo, error) {
+func installInContainer(ctx context.Context, c *container.Container, ext pgxman.InstallExtension, debug bool) (*container.ContainerInfo, error) {
 	s := spinner.New(flagDebug)
 	s.WithIndicator(fmt.Sprintf("Installing %s...\n", ext))
 	defer s.Stop()
@@ -240,6 +240,10 @@ func installInContainer(ctx context.Context, c *container.Container, ext pgxman.
 		}
 
 		s.WithDone(fmt.Sprintf("[%s] %s\n", errorMark, ext))
+
+		if debug {
+			return nil, fmt.Errorf("failed to install %s in a container: %w", ext, err)
+		}
 		return nil, fmt.Errorf("failed to install %s in a container, run with `--debug` to see the full error: %w", ext, err)
 	}
 

--- a/internal/cmd/pgxman/container.go
+++ b/internal/cmd/pgxman/container.go
@@ -8,6 +8,7 @@ import (
 	"regexp"
 	"strings"
 	"text/template"
+	"time"
 
 	"github.com/pgxman/pgxman"
 	"github.com/pgxman/pgxman/internal/config"
@@ -21,6 +22,7 @@ import (
 
 var (
 	flagContainerInstallRunnerImage string
+	flagContainerInstallTimeout     time.Duration
 	flagContainerInstallPGVersion   string
 )
 
@@ -105,6 +107,7 @@ is NAME=VERSION.`, action),
 
 	cmd.PersistentFlags().StringVar(&flagContainerInstallPGVersion, "pg", defPGVer, fmt.Sprintf(c.String(action)+" the extension for the PostgreSQL version. Supported values are %s.", strings.Join(supportedPGVersions(), ", ")))
 	cmd.PersistentFlags().StringVar(&flagContainerInstallRunnerImage, "runner-image", "", "Override the default runner image")
+	cmd.PersistentFlags().DurationVar(&flagContainerInstallTimeout, "timeout", 60*time.Second, "Timeout for the container to start")
 
 	return cmd
 }
@@ -134,6 +137,7 @@ func runContainerInstall(upgrade bool) func(c *cobra.Command, args []string) err
 				container.WithRunnerImage(flagContainerInstallRunnerImage),
 				container.WithConfigDir(config.ConfigDir()),
 				container.WithDebug(flagDebug),
+				container.WithTimeout(flagContainerInstallTimeout),
 			)
 			info *container.ContainerInfo
 		)

--- a/internal/container/container.go
+++ b/internal/container/container.go
@@ -11,6 +11,7 @@ import (
 	"path/filepath"
 	"sort"
 	"text/template"
+	"time"
 
 	cp "github.com/otiai10/copy"
 	"github.com/pgxman/pgxman"
@@ -45,6 +46,7 @@ type Container struct {
 type ContainerOpt struct {
 	runnerImage string
 	configDir   string
+	timeout     time.Duration
 	debug       bool
 }
 
@@ -65,6 +67,12 @@ func WithConfigDir(dir string) ContainerOptFunc {
 func WithDebug(debug bool) ContainerOptFunc {
 	return func(o *ContainerOpt) {
 		o.debug = debug
+	}
+}
+
+func WithTimeout(timeout time.Duration) ContainerOptFunc {
+	return func(o *ContainerOpt) {
+		o.timeout = timeout
 	}
 }
 
@@ -160,7 +168,7 @@ func (c *Container) Install(ctx context.Context, ext pgxman.InstallExtension) (*
 		"up",
 		"--build",
 		"--wait",
-		"--wait-timeout", "60",
+		"--wait-timeout", fmt.Sprintf("%.0f", c.Config.timeout.Seconds()),
 		"--remove-orphans",
 		"--detach",
 	)

--- a/internal/container/container.go
+++ b/internal/container/container.go
@@ -160,7 +160,7 @@ func (c *Container) Install(ctx context.Context, ext pgxman.InstallExtension) (*
 		"up",
 		"--build",
 		"--wait",
-		"--wait-timeout", "10",
+		"--wait-timeout", "60",
 		"--remove-orphans",
 		"--detach",
 	)

--- a/internal/e2etest/container_test.go
+++ b/internal/e2etest/container_test.go
@@ -5,6 +5,7 @@ import (
 	"os"
 	"path/filepath"
 	"testing"
+	"time"
 
 	"github.com/pgxman/pgxman"
 	"github.com/pgxman/pgxman/internal/container"
@@ -19,6 +20,7 @@ func TestContainer(t *testing.T) {
 	c := container.NewContainer(
 		container.WithRunnerImage(flagRunnerPostgres15Image),
 		container.WithConfigDir(configDir),
+		container.WithTimeout(60*time.Second),
 	)
 	wantExt := pgxman.InstallExtension{
 		PackExtension: pgxman.PackExtension{


### PR DESCRIPTION
I'm still getting locale issues for the official `postgres` docker image:

```
DEBU pgxman_runner_15  | initdb: error: invalid locale settings; check LANG and LC_* environment variables
DEBU pgxman_runner_15  | The files belonging to this database system will be owned by user "postgres".
DEBU pgxman_runner_15  | This user must also own the server process.
```

This brings back the locale fix for the builder image and adds the fix to the runner image. It might be a regression upstream or the existing fix is not enough. This fix poses no harm even if upstream fixes it later. 

Besides, this PR cleans up disk space before running e2etest because it can run out of space sometimes: https://github.com/pgxman/pgxman/actions/runs/7833311680/job/21499077490#step:7:1236. And it adds more debugging info when `pgxman container install` fails.