### PR TITLE
[HYD-792] Implement `pgxman auth logout`

### DIFF
--- a/cmd/pgxman/main.go
+++ b/cmd/pgxman/main.go
@@ -1,13 +1,42 @@
 package main
 
 import (
+	"context"
+	"fmt"
+	"io"
 	"os"
 
 	"github.com/pgxman/pgxman/internal/cmd/pgxman"
 )
 
+type exitCode int
+
+const (
+	exitOK    exitCode = 0
+	exitError exitCode = 1
+)
+
 func main() {
-	if err := pgxman.Execute(); err != nil {
-		os.Exit(1)
+	code := mainRun()
+	os.Exit(int(code))
+}
+
+func mainRun() exitCode {
+	ctx := context.Background()
+
+	cmd, err := pgxman.Execute(ctx)
+	if err != nil {
+		printError(os.Stderr, err)
+		return exitError
 	}
+
+	if !cmd.Runnable() {
+		return exitError
+	}
+
+	return exitOK
+}
+
+func printError(out io.Writer, err error) {
+	fmt.Fprintln(out, err)
 }

--- a/cmd/pgxman/main.go
+++ b/cmd/pgxman/main.go
@@ -2,10 +2,12 @@ package main
 
 import (
 	"context"
+	"errors"
 	"fmt"
 	"io"
 	"os"
 
+	"github.com/pgxman/pgxman/internal/cmd/cmdutil"
 	"github.com/pgxman/pgxman/internal/cmd/pgxman"
 )
 
@@ -26,6 +28,10 @@ func mainRun() exitCode {
 
 	cmd, err := pgxman.Execute(ctx)
 	if err != nil {
+		if errors.Is(err, cmdutil.SilentError) {
+			return exitError
+		}
+
 		printError(os.Stderr, err)
 		return exitError
 	}

--- a/installer.go
+++ b/installer.go
@@ -3,6 +3,8 @@ package pgxman
 import (
 	"context"
 	"fmt"
+
+	"github.com/pgxman/pgxman/internal/iostreams"
 )
 
 const DefaultPackAPIVersion = "v1"
@@ -100,6 +102,6 @@ func (p Postgres) Validate() error {
 type Installer interface {
 	Install(ctx context.Context, ext InstallExtension) error
 	Upgrade(ctx context.Context, ext InstallExtension) error
-	PreInstallCheck(ctx context.Context, exts []InstallExtension, io IO) error
-	PreUpgradeCheck(ctx context.Context, exts []InstallExtension, io IO) error
+	PreInstallCheck(ctx context.Context, exts []InstallExtension, io *iostreams.IOStreams) error
+	PreUpgradeCheck(ctx context.Context, exts []InstallExtension, io *iostreams.IOStreams) error
 }

--- a/internal/auth/auth.go
+++ b/internal/auth/auth.go
@@ -64,6 +64,10 @@ func Login(ctx context.Context, opts LoginOptions) error {
 	return opts.AfterLogin(string(user.Email))
 }
 
+func Logout(registryURL *url.URL) error {
+	return keyring.Delete(keyringServiceName(registryURL.Host), "")
+}
+
 func Token(registryURL *url.URL) (string, error) {
 	return keyring.Get(keyringServiceName(registryURL.Host), "")
 }

--- a/internal/auth/auth.go
+++ b/internal/auth/auth.go
@@ -14,7 +14,7 @@ type LoginOptions struct {
 	Config      *config.Config
 	RegistryURL *url.URL
 
-	BeforeLogin func(registryHostname, registryLoginURL string) (bool, error)
+	BeforeLogin func(registryHostname, registryLoginURL string) error
 	AfterLogin  func(email string) error
 }
 
@@ -34,12 +34,9 @@ func Login(ctx context.Context, opts LoginOptions) error {
 		_ = flow.Done()
 	}()
 
-	con, err := opts.BeforeLogin(opts.RegistryURL.Host, flow.BrowserURL())
+	err = opts.BeforeLogin(opts.RegistryURL.Host, flow.BrowserURL())
 	if err != nil {
 		return err
-	}
-	if !con {
-		return nil
 	}
 
 	token, err := flow.WaitForToken(ctx)

--- a/internal/cmd/cmdutil/errors.go
+++ b/internal/cmd/cmdutil/errors.go
@@ -1,0 +1,5 @@
+package cmdutil
+
+import "errors"
+
+var SilentError = errors.New("SilentError")

--- a/internal/cmd/pgxman/auth.go
+++ b/internal/cmd/pgxman/auth.go
@@ -123,7 +123,14 @@ func runAuthLogout(cmd *cobra.Command, args []string) error {
 		return err
 	}
 
-	return auth.Logout(u)
+	logger := log.NewTextLogger()
+	err = auth.Logout(u)
+	if err != nil {
+		logger.Debug("error logging out", "error", err)
+		return fmt.Errorf("not logged in to %s", u.Host)
+	}
+
+	return nil
 }
 
 func runAuthToken(cmd *cobra.Command, args []string) error {

--- a/internal/cmd/pgxman/auth.go
+++ b/internal/cmd/pgxman/auth.go
@@ -135,6 +135,8 @@ func runAuthLogout(cmd *cobra.Command, args []string) error {
 		return fmt.Errorf("not logged in to %s", u.Host)
 	}
 
+	fmt.Printf("Logged out of %s\n", u.Host)
+
 	return nil
 }
 

--- a/internal/cmd/pgxman/auth.go
+++ b/internal/cmd/pgxman/auth.go
@@ -1,12 +1,14 @@
 package pgxman
 
 import (
+	"errors"
 	"fmt"
 	"net/url"
 
 	"github.com/eiannone/keyboard"
 	"github.com/pgxman/pgxman"
 	"github.com/pgxman/pgxman/internal/auth"
+	"github.com/pgxman/pgxman/internal/cmd/cmdutil"
 	"github.com/pgxman/pgxman/internal/config"
 	"github.com/pgxman/pgxman/internal/log"
 	"github.com/pkg/browser"
@@ -80,30 +82,27 @@ func runAuthLogin(cmd *cobra.Command, args []string) error {
 	}
 
 	io := pgxman.NewStdIO()
+	logger := log.NewTextLogger()
 
 	if err := auth.Login(
 		cmd.Context(),
 		auth.LoginOptions{
 			Config:      cfg,
 			RegistryURL: u,
-			BeforeLogin: func(registryHostname, registryLoginURL string) (bool, error) {
-				con, err := io.Prompt(
+			BeforeLogin: func(registryHostname, registryLoginURL string) error {
+				if err := io.Prompt(
 					fmt.Sprintf("Press Enter to log in to %s in your browser...", registryHostname),
 					nil,
 					[]keyboard.Key{keyboard.KeyEnter},
-				)
-				if err != nil {
-					return false, err
-				}
-				if !con {
-					return false, nil
+				); err != nil {
+					return err
 				}
 
 				if err := browser.OpenURL(registryLoginURL); err != nil {
-					return false, err
+					return err
 				}
 
-				return true, nil
+				return nil
 			},
 			AfterLogin: func(email string) error {
 				fmt.Fprintf(io.Stdout, "Logged in as %s\n", email)
@@ -111,6 +110,12 @@ func runAuthLogin(cmd *cobra.Command, args []string) error {
 			},
 		},
 	); err != nil {
+		logger.Debug("error logging in", "error", err)
+
+		if errors.Is(err, pgxman.ErrAbortPrompt) {
+			return cmdutil.SilentError
+		}
+
 		return err
 	}
 

--- a/internal/cmd/pgxman/auth.go
+++ b/internal/cmd/pgxman/auth.go
@@ -23,6 +23,7 @@ func newAuthCmd() *cobra.Command {
 	cmd.AddCommand(newAuthLoginCmd())
 	cmd.AddCommand(newAuthStatusCmd())
 	cmd.AddCommand(newAuthTokenCmd())
+	cmd.AddCommand(newAuthLogoutCmd())
 
 	return cmd
 }
@@ -32,6 +33,16 @@ func newAuthLoginCmd() *cobra.Command {
 		Use:   "login",
 		Short: "Log in to a registry account",
 		RunE:  runAuthLogin,
+	}
+
+	return cmd
+}
+
+func newAuthLogoutCmd() *cobra.Command {
+	cmd := &cobra.Command{
+		Use:   "logout",
+		Short: "Log out of a registry account",
+		RunE:  runAuthLogout,
 	}
 
 	return cmd
@@ -104,6 +115,15 @@ func runAuthLogin(cmd *cobra.Command, args []string) error {
 	}
 
 	return nil
+}
+
+func runAuthLogout(cmd *cobra.Command, args []string) error {
+	u, err := url.ParseRequestURI(flagRegistryURL)
+	if err != nil {
+		return err
+	}
+
+	return auth.Logout(u)
 }
 
 func runAuthToken(cmd *cobra.Command, args []string) error {

--- a/internal/cmd/pgxman/auth.go
+++ b/internal/cmd/pgxman/auth.go
@@ -6,10 +6,10 @@ import (
 	"net/url"
 
 	"github.com/eiannone/keyboard"
-	"github.com/pgxman/pgxman"
 	"github.com/pgxman/pgxman/internal/auth"
 	"github.com/pgxman/pgxman/internal/cmd/cmdutil"
 	"github.com/pgxman/pgxman/internal/config"
+	"github.com/pgxman/pgxman/internal/iostreams"
 	"github.com/pgxman/pgxman/internal/log"
 	"github.com/pkg/browser"
 	"github.com/spf13/cobra"
@@ -81,7 +81,7 @@ func runAuthLogin(cmd *cobra.Command, args []string) error {
 		return err
 	}
 
-	io := pgxman.NewStdIO()
+	io := iostreams.NewIOStreams()
 	logger := log.NewTextLogger()
 
 	if err := auth.Login(
@@ -112,7 +112,7 @@ func runAuthLogin(cmd *cobra.Command, args []string) error {
 	); err != nil {
 		logger.Debug("error logging in", "error", err)
 
-		if errors.Is(err, pgxman.ErrAbortPrompt) {
+		if errors.Is(err, iostreams.ErrAbortPrompt) {
 			return cmdutil.SilentError
 		}
 

--- a/internal/cmd/pgxman/install_linux.go
+++ b/internal/cmd/pgxman/install_linux.go
@@ -12,6 +12,7 @@ import (
 
 	"github.com/pgxman/pgxman"
 	"github.com/pgxman/pgxman/internal/errorsx"
+	"github.com/pgxman/pgxman/internal/iostreams"
 	"github.com/pgxman/pgxman/internal/log"
 	"github.com/pgxman/pgxman/internal/pg"
 	"github.com/pgxman/pgxman/internal/plugin"
@@ -151,7 +152,7 @@ func runInstallOrUpgrade(upgrade bool) func(c *cobra.Command, args []string) err
 				checkFunc = i.PreUpgradeCheck
 			}
 
-			if err := checkFunc(cmd.Context(), exts, pgxman.NewStdIO()); err != nil {
+			if err := checkFunc(cmd.Context(), exts, iostreams.NewIOStreams()); err != nil {
 				return err
 			}
 		}

--- a/internal/cmd/pgxman/pack.go
+++ b/internal/cmd/pgxman/pack.go
@@ -10,6 +10,7 @@ import (
 
 	"github.com/pgxman/pgxman"
 	"github.com/pgxman/pgxman/internal/errorsx"
+	"github.com/pgxman/pgxman/internal/iostreams"
 	"github.com/pgxman/pgxman/internal/log"
 	"github.com/pgxman/pgxman/internal/plugin"
 	"github.com/pgxman/pgxman/internal/tui/spinner"
@@ -103,7 +104,7 @@ func runPackInstall(cmd *cobra.Command, args []string) error {
 	}
 
 	if !flagPackInstallYes {
-		if err := i.PreInstallCheck(cmd.Context(), exts, pgxman.NewStdIO()); err != nil {
+		if err := i.PreInstallCheck(cmd.Context(), exts, iostreams.NewIOStreams()); err != nil {
 			return err
 		}
 	}

--- a/internal/cmd/pgxman/root.go
+++ b/internal/cmd/pgxman/root.go
@@ -26,10 +26,11 @@ var (
 
 func Command() *cobra.Command {
 	root := &cobra.Command{
-		Use:          "pgxman",
-		Short:        "PostgreSQL Extension Manager",
-		Version:      pgxman.Version,
-		SilenceUsage: true,
+		Use:           "pgxman",
+		Short:         "PostgreSQL Extension Manager",
+		Version:       pgxman.Version,
+		SilenceUsage:  true,
+		SilenceErrors: true,
 		PersistentPreRunE: func(cmd *cobra.Command, args []string) error {
 			if flagDebug {
 				log.SetLevel(slog.LevelDebug)
@@ -56,8 +57,8 @@ func Command() *cobra.Command {
 	return root
 }
 
-func Execute() error {
-	return Command().Execute()
+func Execute(ctx context.Context) (*cobra.Command, error) {
+	return Command().ExecuteContextC(ctx)
 }
 
 func checkUpgrade(ctx context.Context) error {

--- a/internal/iostreams/iostreams.go
+++ b/internal/iostreams/iostreams.go
@@ -1,0 +1,61 @@
+package iostreams
+
+import (
+	"fmt"
+	"io"
+	"os"
+	"slices"
+
+	"github.com/eiannone/keyboard"
+	"golang.org/x/term"
+)
+
+var (
+	ErrAbortPrompt = fmt.Errorf("abort prompt")
+	ErrNotTerminal = fmt.Errorf("not a terminal")
+)
+
+type IOStreams struct {
+	Stdin  io.Reader
+	Stdout io.Writer
+	Stderr io.Writer
+}
+
+func (i *IOStreams) IsTerminal() bool {
+	return term.IsTerminal(int(os.Stdout.Fd()))
+}
+
+func (i *IOStreams) Prompt(msg string, continueChars []rune, continueKeys []keyboard.Key) error {
+	if !i.IsTerminal() {
+		return ErrNotTerminal
+	}
+
+	if err := keyboard.Open(); err != nil {
+		return err
+	}
+	defer keyboard.Close()
+
+	fmt.Fprint(i.Stdout, msg+" ")
+	for {
+		char, key, err := keyboard.GetKey()
+		if err != nil {
+			return err
+		}
+
+		if slices.Contains(continueChars, char) || slices.Contains(continueKeys, key) {
+			fmt.Println()
+			return nil
+		} else {
+			fmt.Println()
+			return ErrAbortPrompt
+		}
+	}
+}
+
+func NewIOStreams() *IOStreams {
+	return &IOStreams{
+		Stdin:  os.Stdin,
+		Stdout: os.Stdout,
+		Stderr: os.Stderr,
+	}
+}

--- a/internal/keyring/keyring.go
+++ b/internal/keyring/keyring.go
@@ -63,6 +63,9 @@ func Delete(service, user string) error {
 	}()
 	select {
 	case err := <-ch:
+		if errors.Is(err, keyring.ErrNotFound) {
+			return ErrNotFound
+		}
 		return err
 	case <-time.After(3 * time.Second):
 		return &TimeoutError{"timeout while trying to delete secret from keyring"}

--- a/internal/plugin/debian/installer.go
+++ b/internal/plugin/debian/installer.go
@@ -9,6 +9,7 @@ import (
 
 	"github.com/eiannone/keyboard"
 	"github.com/pgxman/pgxman"
+	"github.com/pgxman/pgxman/internal/iostreams"
 	"github.com/pgxman/pgxman/internal/log"
 )
 
@@ -24,15 +25,15 @@ func (i *DebianInstaller) Upgrade(ctx context.Context, ext pgxman.InstallExtensi
 	return i.installOrUpgrade(ctx, ext, true)
 }
 
-func (i *DebianInstaller) PreInstallCheck(ctx context.Context, exts []pgxman.InstallExtension, io pgxman.IO) error {
+func (i *DebianInstaller) PreInstallCheck(ctx context.Context, exts []pgxman.InstallExtension, io *iostreams.IOStreams) error {
 	return i.installOrUpgradeCheck(ctx, exts, io, false)
 }
 
-func (i *DebianInstaller) PreUpgradeCheck(ctx context.Context, exts []pgxman.InstallExtension, io pgxman.IO) error {
+func (i *DebianInstaller) PreUpgradeCheck(ctx context.Context, exts []pgxman.InstallExtension, io *iostreams.IOStreams) error {
 	return i.installOrUpgradeCheck(ctx, exts, io, true)
 }
 
-func (i DebianInstaller) installOrUpgradeCheck(ctx context.Context, exts []pgxman.InstallExtension, io pgxman.IO, upgrade bool) error {
+func (i DebianInstaller) installOrUpgradeCheck(ctx context.Context, exts []pgxman.InstallExtension, io *iostreams.IOStreams, upgrade bool) error {
 	if err := checkRootAccess(); err != nil {
 		return err
 	}
@@ -146,7 +147,7 @@ func newAptPackage(ext pgxman.InstallExtension) (AptPackage, error) {
 	return aptPkg, nil
 }
 
-func promptInstallOrUpgrade(io pgxman.IO, debPkgs []AptPackage, sources []AptSource, upgrade bool) error {
+func promptInstallOrUpgrade(io *iostreams.IOStreams, debPkgs []AptPackage, sources []AptSource, upgrade bool) error {
 	if !io.IsTerminal() {
 		return nil
 	}
@@ -178,7 +179,7 @@ func promptInstallOrUpgrade(io pgxman.IO, debPkgs []AptPackage, sources []AptSou
 
 	err := io.Prompt(strings.Join(out, "\n"), []rune{'y', 'Y'}, []keyboard.Key{keyboard.KeyEnter})
 	if err != nil {
-		if errors.Is(err, pgxman.ErrAbortPrompt) {
+		if errors.Is(err, iostreams.ErrAbortPrompt) {
 			return fmt.Errorf(abortMsg)
 		}
 

--- a/internal/plugin/debian/installer.go
+++ b/internal/plugin/debian/installer.go
@@ -2,6 +2,7 @@ package debian
 
 import (
 	"context"
+	"errors"
 	"fmt"
 	"os"
 	"strings"
@@ -175,13 +176,13 @@ func promptInstallOrUpgrade(io pgxman.IO, debPkgs []AptPackage, sources []AptSou
 
 	out = append(out, "Do you want to continue? [Y/n]")
 
-	con, err := io.Prompt(strings.Join(out, "\n"), []rune{'y', 'Y'}, []keyboard.Key{keyboard.KeyEnter})
+	err := io.Prompt(strings.Join(out, "\n"), []rune{'y', 'Y'}, []keyboard.Key{keyboard.KeyEnter})
 	if err != nil {
-		return err
-	}
+		if errors.Is(err, pgxman.ErrAbortPrompt) {
+			return fmt.Errorf(abortMsg)
+		}
 
-	if !con {
-		return fmt.Errorf(abortMsg)
+		return err
 	}
 
 	return nil

--- a/io.go
+++ b/io.go
@@ -5,63 +5,10 @@ import (
 	"io"
 	"os"
 	"path/filepath"
-	"slices"
 
 	"dario.cat/mergo"
-	"github.com/eiannone/keyboard"
-	"golang.org/x/term"
 	"sigs.k8s.io/yaml"
 )
-
-var (
-	ErrAbortPrompt = fmt.Errorf("abort prompt")
-	ErrNotTerminal = fmt.Errorf("not a terminal")
-)
-
-type IO struct {
-	Stdin  io.Reader
-	Stdout io.Writer
-	Stderr io.Writer
-}
-
-func (i IO) IsTerminal() bool {
-	return term.IsTerminal(int(os.Stdout.Fd()))
-}
-
-func (i IO) Prompt(msg string, continueChars []rune, continueKeys []keyboard.Key) error {
-	if !i.IsTerminal() {
-		return ErrNotTerminal
-	}
-
-	if err := keyboard.Open(); err != nil {
-		return err
-	}
-	defer keyboard.Close()
-
-	fmt.Fprint(i.Stdout, msg+" ")
-	for {
-		char, key, err := keyboard.GetKey()
-		if err != nil {
-			return err
-		}
-
-		if slices.Contains(continueChars, char) || slices.Contains(continueKeys, key) {
-			fmt.Println()
-			return nil
-		} else {
-			fmt.Println()
-			return ErrAbortPrompt
-		}
-	}
-}
-
-func NewStdIO() IO {
-	return IO{
-		Stdin:  os.Stdin,
-		Stdout: os.Stdout,
-		Stderr: os.Stderr,
-	}
-}
 
 func WriteExtension(path string, ext Extension) error {
 	b, err := yaml.Marshal(ext)


### PR DESCRIPTION
Implement `pgxman auth logout`. A demo of the full `pgxman auth` experience:

```
$ pgxman auth login
Press Enter to log in to registry.pgxman.com in your browser...
Logged in as o@hydra.so
$ pgxman auth status
Logged in to registry.pgxman.com as o@hydra.so
$ pgxman auth token
...TOKEN...
$ pgxman auth logout
Logged out of registry.pgxman.com
$ pgxman auth logout
not logged in to registry.pgxman.com
```

This PR includes refactoring to `iostreams` and exit code.