### PR TITLE
[HYD-790] Implement `pgxman auth signup`

### DIFF
--- a/internal/auth/auth.go
+++ b/internal/auth/auth.go
@@ -13,6 +13,7 @@ import (
 type LoginOptions struct {
 	Config      *config.Config
 	RegistryURL *url.URL
+	Screen      Screen
 
 	BeforeLogin func(registryHostname, registryLoginURL string) error
 	AfterLogin  func(email string) error
@@ -25,6 +26,7 @@ func Login(ctx context.Context, opts LoginOptions) error {
 			Scopes:   []string{"openid", "write:publish_extension"},
 			Audience: opts.Config.OAuth.Audience,
 			Endpoint: opts.Config.OAuth.Endpoint,
+			Screen:   opts.Screen,
 		},
 	)
 	if err != nil {

--- a/internal/auth/flow.go
+++ b/internal/auth/flow.go
@@ -10,12 +10,20 @@ import (
 	"golang.org/x/oauth2"
 )
 
+type Screen int
+
+const (
+	LoginScreen Screen = iota
+	SignupScreen
+)
+
 type FlowParams struct {
 	ClientID     string
 	ClientSecret string
 	Scopes       []string
 	Audience     string
 	Endpoint     string
+	Screen       Screen
 }
 
 func (p FlowParams) Validate() error {
@@ -75,11 +83,20 @@ func (f *Flow) Done() error {
 }
 
 func (f *Flow) BrowserURL() string {
+	var screenHint oauth2.AuthCodeOption
+	switch f.params.Screen {
+	case SignupScreen:
+		screenHint = oauth2.SetAuthURLParam("screen_hint", "signup")
+	default:
+		screenHint = oauth2.SetAuthURLParam("prompt", "login")
+	}
+
 	return f.conf().AuthCodeURL(
 		"",
 		oauth2.AccessTypeOffline,
 		oauth2.S256ChallengeOption(f.verifier),
 		oauth2.SetAuthURLParam("audience", f.params.Audience),
+		screenHint,
 	)
 }
 

--- a/internal/cmd/pgxman/auth.go
+++ b/internal/cmd/pgxman/auth.go
@@ -1,6 +1,7 @@
 package pgxman
 
 import (
+	"context"
 	"errors"
 	"fmt"
 	"net/url"
@@ -23,6 +24,7 @@ func newAuthCmd() *cobra.Command {
 	}
 
 	cmd.AddCommand(newAuthLoginCmd())
+	cmd.AddCommand(newAuthSignupCmd())
 	cmd.AddCommand(newAuthStatusCmd())
 	cmd.AddCommand(newAuthTokenCmd())
 	cmd.AddCommand(newAuthLogoutCmd())
@@ -35,6 +37,16 @@ func newAuthLoginCmd() *cobra.Command {
 		Use:   "login",
 		Short: "Log in to a registry account",
 		RunE:  runAuthLogin,
+	}
+
+	return cmd
+}
+
+func newAuthSignupCmd() *cobra.Command {
+	cmd := &cobra.Command{
+		Use:   "signup",
+		Short: "Sign up a registry account",
+		RunE:  runAuthSignup,
 	}
 
 	return cmd
@@ -70,57 +82,12 @@ func newAuthTokenCmd() *cobra.Command {
 	return cmd
 }
 
+func runAuthSignup(cmd *cobra.Command, args []string) error {
+	return loginOrSignup(cmd.Context(), auth.SignupScreen)
+}
+
 func runAuthLogin(cmd *cobra.Command, args []string) error {
-	cfg, err := config.Read()
-	if err != nil {
-		return err
-	}
-
-	u, err := url.ParseRequestURI(flagRegistryURL)
-	if err != nil {
-		return err
-	}
-
-	io := iostreams.NewIOStreams()
-	logger := log.NewTextLogger()
-
-	if err := auth.Login(
-		cmd.Context(),
-		auth.LoginOptions{
-			Config:      cfg,
-			RegistryURL: u,
-			Screen:      auth.LoginScreen,
-			BeforeLogin: func(registryHostname, registryLoginURL string) error {
-				if err := io.Prompt(
-					fmt.Sprintf("Press Enter to log in to %s in your browser...", registryHostname),
-					nil,
-					[]keyboard.Key{keyboard.KeyEnter},
-				); err != nil {
-					return err
-				}
-
-				if err := browser.OpenURL(registryLoginURL); err != nil {
-					return err
-				}
-
-				return nil
-			},
-			AfterLogin: func(email string) error {
-				fmt.Fprintf(io.Stdout, "Logged in as %s\n", email)
-				return nil
-			},
-		},
-	); err != nil {
-		logger.Debug("error logging in", "error", err)
-
-		if errors.Is(err, iostreams.ErrAbortPrompt) {
-			return cmdutil.SilentError
-		}
-
-		return err
-	}
-
-	return nil
+	return loginOrSignup(cmd.Context(), auth.LoginScreen)
 }
 
 func runAuthLogout(cmd *cobra.Command, args []string) error {
@@ -177,5 +144,57 @@ func runAuthStatus(cmd *cobra.Command, args []string) error {
 	}
 
 	fmt.Printf("Logged in to %s as %s\n", u.Host, user.Email)
+	return nil
+}
+
+func loginOrSignup(ctx context.Context, screen auth.Screen) error {
+	cfg, err := config.Read()
+	if err != nil {
+		return err
+	}
+
+	u, err := url.ParseRequestURI(flagRegistryURL)
+	if err != nil {
+		return err
+	}
+
+	io := iostreams.NewIOStreams()
+	logger := log.NewTextLogger()
+
+	if err := auth.Login(
+		ctx,
+		auth.LoginOptions{
+			Config:      cfg,
+			RegistryURL: u,
+			Screen:      screen,
+			BeforeLogin: func(registryHostname, registryLoginURL string) error {
+				if err := io.Prompt(
+					fmt.Sprintf("Press Enter to log in to %s in your browser...", registryHostname),
+					nil,
+					[]keyboard.Key{keyboard.KeyEnter},
+				); err != nil {
+					return err
+				}
+
+				if err := browser.OpenURL(registryLoginURL); err != nil {
+					return err
+				}
+
+				return nil
+			},
+			AfterLogin: func(email string) error {
+				fmt.Fprintf(io.Stdout, "Logged in as %s\n", email)
+				return nil
+			},
+		},
+	); err != nil {
+		logger.Debug("error logging in", "error", err)
+		if errors.Is(err, iostreams.ErrAbortPrompt) {
+			return cmdutil.SilentError
+		}
+
+		return err
+	}
+
 	return nil
 }

--- a/internal/cmd/pgxman/auth.go
+++ b/internal/cmd/pgxman/auth.go
@@ -158,8 +158,10 @@ func loginOrSignup(ctx context.Context, screen auth.Screen) error {
 		return err
 	}
 
-	io := iostreams.NewIOStreams()
-	logger := log.NewTextLogger()
+	var (
+		io     = iostreams.NewIOStreams()
+		logger = log.NewTextLogger()
+	)
 
 	if err := auth.Login(
 		ctx,
@@ -168,8 +170,16 @@ func loginOrSignup(ctx context.Context, screen auth.Screen) error {
 			RegistryURL: u,
 			Screen:      screen,
 			BeforeLogin: func(registryHostname, registryLoginURL string) error {
+				var promptMsg string
+				switch screen {
+				case auth.SignupScreen:
+					promptMsg = fmt.Sprintf("Press Enter to sign up at %s in your browser...", registryHostname)
+				default:
+					promptMsg = fmt.Sprintf("Press Enter to log in to %s in your browser...", registryHostname)
+				}
+
 				if err := io.Prompt(
-					fmt.Sprintf("Press Enter to log in to %s in your browser...", registryHostname),
+					promptMsg,
 					nil,
 					[]keyboard.Key{keyboard.KeyEnter},
 				); err != nil {

--- a/internal/cmd/pgxman/auth.go
+++ b/internal/cmd/pgxman/auth.go
@@ -89,6 +89,7 @@ func runAuthLogin(cmd *cobra.Command, args []string) error {
 		auth.LoginOptions{
 			Config:      cfg,
 			RegistryURL: u,
+			Screen:      auth.LoginScreen,
 			BeforeLogin: func(registryHostname, registryLoginURL string) error {
 				if err := io.Prompt(
 					fmt.Sprintf("Press Enter to log in to %s in your browser...", registryHostname),


### PR DESCRIPTION
Implement `pgxman auth signup`. Auth0 allows landing users by [setting the `screen_hint` param](https://auth0.com/docs/authenticate/login/auth0-universal-login/new-experience#signup). A demo:


```
$ pgxman auth signup
Press Enter to sign up at registry.pgxman.com in your browser...
Logged in as o@hydra.so
```