### PR TITLE
Move container install test to Linux

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -117,6 +117,8 @@ jobs:
       - name: Run tests
         run: |
           make tools goreleaser
+
+          # pack install test
           cat <<EOS > /tmp/pgxman.yaml
           apiVersion: v1
           postgres:
@@ -127,19 +129,19 @@ jobs:
             - name: parquet_s3_fdw
           EOS
           PGXMAN_INSTALLER_DEBIAN_PACKAGE_DIR=$(pwd)/dist ./install.sh /tmp/pgxman.yaml
+
+          # install test
           sudo pgxman install pg_ivm pg_bm25 --debug
+
+          # container install test
+          RUNNER_TARGET=runner-postgres-15 RUNNER_POSTGRES_15_IMAGE=ghcr.io/pgxman/runner/postgres/15:dev make docker_load_runner
+          pgxman container install pgvector postgis parquet_s3_fdw --debug --runner-image ghcr.io/pgxman/runner/postgres/15:dev
   mac_install_test:
     name: Mac Install Test
     needs: [build, test, vet]
     runs-on: macos-13
     steps:
       - uses: actions/checkout@v4
-      - uses: douglascamata/setup-docker-macos-action@main
-      - name: Setup Docker buildx
-        run: |
-          brew install docker-buildx
-          mkdir -p ~/.docker/cli-plugins
-          ln -sfn "$(brew --prefix docker-buildx)/bin/docker-buildx" ~/.docker/cli-plugins/docker-buildx
       - uses: actions/setup-go@v5
         with:
           go-version-file: go.mod
@@ -150,10 +152,8 @@ jobs:
           HOMEBREW_GITHUB_PACKAGES_TOKEN: ${{ github.token }}
           HOMEBREW_GITHUB_PACKAGES_USER: ${{ github.actor }}
         run: |
-          RUNNER_TARGET=runner-postgres-15 RUNNER_POSTGRES_15_IMAGE=ghcr.io/pgxman/runner/postgres/15:dev make docker_load_runner
           GORELEASER_GITHUB_RELEASE_DOWNLOAD_URL=file://$(pwd)/dist make tools goreleaser
           PGXMAN_INSTALLER_HOMEBREW_TAP=./dist/homebrew/Formula/pgxman.rb ./install.sh
-          pgxman install pgvector postgis parquet_s3_fdw --debug --runner-image ghcr.io/pgxman/runner/postgres/15:dev
   docker:
     name: Docker
     needs: [e2etest]


### PR DESCRIPTION
Moving the container install test to Linux from MacOS on CI. The Docker setup takes a long time on MacOS (~ 28 mins), so to speed things up, let's move the container install test to Linux and keep only the install script test on MacOS.