### PR TITLE
[HYD-881] Mark `description` field mandatory

### DIFF
--- a/.goreleaser.yml
+++ b/.goreleaser.yml
@@ -58,7 +58,7 @@ brews:
       email: o@hydra.so
     homepage: https://github.com/pgxman/pgxman
     description: PostgreSQL Extensions Manager
-    folder: Formula
+    directory: Formula
     license: "Apache 2.0"
     url_template: '{{ if index .Env "GORELEASER_GITHUB_RELEASE_DOWNLOAD_URL"  }}{{ .Env.GORELEASER_GITHUB_RELEASE_DOWNLOAD_URL }}/{{ .ArtifactName }}{{ else }}https://github.com/pgxman/pgxman/releases/download/{{ .Tag }}/{{ .ArtifactName }}{{ end }}'
     custom_block: |

--- a/extension.go
+++ b/extension.go
@@ -50,12 +50,12 @@ type ExtensionCommon struct {
 	Name        string       `json:"name"`
 	Repository  string       `json:"repository"`
 	Maintainers []Maintainer `json:"maintainers"`
+	Description string       `json:"description"`
 
 	// optional
-	Description string   `json:"description,omitempty"`
-	License     string   `json:"license,omitempty"`
-	Keywords    []string `json:"keywords,omitempty"`
-	Homepage    string   `json:"homepage,omitempty"`
+	License  string   `json:"license,omitempty"`
+	Keywords []string `json:"keywords,omitempty"`
+	Homepage string   `json:"homepage,omitempty"`
 }
 
 func (ext ExtensionCommon) Validate() error {
@@ -67,6 +67,10 @@ func (ext ExtensionCommon) Validate() error {
 
 	if ext.Repository == "" {
 		err = errors.Join(err, fmt.Errorf("repository is required"))
+	}
+
+	if ext.Description == "" {
+		err = errors.Join(err, fmt.Errorf("description is required"))
 	}
 
 	if ext.License != "" {

--- a/internal/cmd/pgxman/args.go
+++ b/internal/cmd/pgxman/args.go
@@ -136,8 +136,10 @@ func (l *ExtensionLocker) Lock(ctx context.Context, exts []pgxman.InstallExtensi
 			installableExt, err := l.Client.GetExtension(ctx, ext.Name)
 			if err != nil {
 				if errors.Is(err, registry.ErrExtensionNotFound) {
-					return nil, &ErrExtNotFound{Name: ext.Name}
+					err = &ErrExtNotFound{Name: ext.Name}
 				}
+
+				return nil, err
 			}
 
 			// if version is not specified, use the latest version
@@ -145,7 +147,7 @@ func (l *ExtensionLocker) Lock(ctx context.Context, exts []pgxman.InstallExtensi
 				installableExt, err = l.Client.GetVersion(ctx, ext.Name, ext.Version)
 				if err != nil {
 					if errors.Is(err, registry.ErrExtensionNotFound) {
-						return nil, &ErrExtVerNotFound{Name: ext.Name, Version: ext.Version}
+						err = &ErrExtVerNotFound{Name: ext.Name, Version: ext.Version}
 					}
 
 					return nil, err

--- a/internal/cmd/pgxman/init.go
+++ b/internal/cmd/pgxman/init.go
@@ -35,8 +35,9 @@ func runInit(c *cobra.Command, args []string) error {
 	ext := &pgxman.Extension{
 		APIVersion: pgxman.DefaultExtensionAPIVersion,
 		ExtensionCommon: pgxman.ExtensionCommon{
-			Name:    "my-pg-extension",
-			License: "PostgreSQL",
+			Name:        "my-pg-extension",
+			Description: "My PostgreSQL extension",
+			License:     "PostgreSQL",
 			Maintainers: []pgxman.Maintainer{
 				{
 					Name:  user.Name,
@@ -102,7 +103,7 @@ func initialModel(pwd string, ext *pgxman.Extension) initModel {
 		ext:        ext,
 		extPath:    filepath.Join(pwd, "extension.yaml"),
 		focusIndex: 0,
-		inputs:     make([]initInput, 5),
+		inputs:     make([]initInput, 6),
 	}
 
 	for i := range m.inputs {
@@ -112,7 +113,7 @@ func initialModel(pwd string, ext *pgxman.Extension) initModel {
 
 		switch i {
 		case 0:
-			t.Label = "Extension name"
+			t.Label = "Name"
 			t.Placeholder = ext.Name
 			t.UpdateExt = func(ext *pgxman.Extension, val string) {
 				ext.Name = val
@@ -122,30 +123,36 @@ func initialModel(pwd string, ext *pgxman.Extension) initModel {
 			t.PromptStyle = focusedStyle
 			t.Focus()
 		case 1:
+			t.Label = "Description"
+			t.Placeholder = ext.Description
+			t.UpdateExt = func(ext *pgxman.Extension, val string) {
+				ext.Description = val
+			}
+		case 2:
 			t.Label = "Version"
 			t.Placeholder = ext.Version
 			t.UpdateExt = func(ext *pgxman.Extension, val string) {
 				ext.Version = val
 			}
-		case 2:
+		case 3:
 			t.Label = "License"
 			t.Placeholder = ext.License
 			t.UpdateExt = func(ext *pgxman.Extension, val string) {
 				ext.License = val
 			}
-		case 3:
+		case 4:
 			t.Label = "Keywords (comma-separated)"
 			t.Placeholder = strings.Join(ext.Keywords, ",")
 			t.UpdateExt = func(ext *pgxman.Extension, val string) {
 				ext.Keywords = splitString(val)
 			}
-		case 4:
+		case 5:
 			t.Label = "Source URL"
 			t.Placeholder = ext.Source
 			t.UpdateExt = func(ext *pgxman.Extension, val string) {
 				ext.Source = val
 			}
-		case 5:
+		case 6:
 			t.Label = "PG versions (comma-separated)"
 
 			var pgvs []string


### PR DESCRIPTION
Mark `description` field mandatory. `pgxman init` also asks for `description` in the prompt.

![Screenshot 2024-05-10 at 9 19 18 AM](https://github.com/pgxman/pgxman/assets/169064/3993ba39-b508-401f-83c2-ce620c022da8)
