### PR TITLE
Skip upgrade check in CI

### DIFF
--- a/.goreleaser.yml
+++ b/.goreleaser.yml
@@ -1,7 +1,7 @@
 project_name: pgxman
 builds:
   - ldflags:
-      - -s -w -X github.com/pgxman/pgxman.Version={{.Version}}
+      - -s -w -X github.com/pgxman/pgxman.Version={{.Version}} -X github.com/pgxman/pgxman.UpdaterEnabled=true
     goos: [darwin, linux]
     goarch: ["386", "amd64", "arm", "arm64"]
     env:

--- a/go.mod
+++ b/go.mod
@@ -28,7 +28,6 @@ require (
 	golang.org/x/exp v0.0.0-20231006140011-7918f672742d
 	golang.org/x/oauth2 v0.20.0
 	golang.org/x/sync v0.7.0
-	golang.org/x/term v0.20.0
 	golang.org/x/text v0.15.0
 	sigs.k8s.io/yaml v1.4.0
 )
@@ -79,6 +78,7 @@ require (
 	github.com/xi2/xz v0.0.0-20171230120015-48954b6210f8 // indirect
 	golang.org/x/mod v0.13.0 // indirect
 	golang.org/x/sys v0.20.0 // indirect
+	golang.org/x/term v0.20.0 // indirect
 	golang.org/x/tools v0.14.0 // indirect
 	gopkg.in/yaml.v2 v2.4.0 // indirect
 	gopkg.in/yaml.v3 v3.0.1 // indirect

--- a/go.mod
+++ b/go.mod
@@ -16,6 +16,7 @@ require (
 	github.com/github/go-spdx/v2 v2.2.0
 	github.com/google/go-github/v57 v57.0.0
 	github.com/google/uuid v1.6.0
+	github.com/mattn/go-isatty v0.0.20
 	github.com/mholt/archiver/v3 v3.5.1
 	github.com/oapi-codegen/runtime v1.1.1
 	github.com/otiai10/copy v1.14.0
@@ -60,7 +61,6 @@ require (
 	github.com/lucasb-eyer/go-colorful v1.2.0 // indirect
 	github.com/mailru/easyjson v0.7.7 // indirect
 	github.com/mattn/go-colorable v0.1.13 // indirect
-	github.com/mattn/go-isatty v0.0.20 // indirect
 	github.com/mattn/go-localereader v0.0.1 // indirect
 	github.com/mattn/go-runewidth v0.0.15 // indirect
 	github.com/mohae/deepcopy v0.0.0-20170929034955-c48cc78d4826 // indirect

--- a/internal/cmd/pgxman/root.go
+++ b/internal/cmd/pgxman/root.go
@@ -10,7 +10,6 @@ import (
 
 	"log/slog"
 
-	"github.com/mattn/go-isatty"
 	"github.com/pgxman/pgxman"
 	"github.com/pgxman/pgxman/internal/auth"
 	"github.com/pgxman/pgxman/internal/log"
@@ -122,23 +121,4 @@ func newReigstryClient() (registry.Client, error) {
 	}
 
 	return registry.NewClient(flagRegistryURL, t)
-}
-
-func shouldCheckForUpgrade() bool {
-	if os.Getenv("PGXMAN_NO_UPGRADE_NOTIFIER") != "" {
-		return false
-	}
-
-	return pgxman.UpdaterEnabled == "true" && !isCI() && isTerminal(os.Stdout) && isTerminal(os.Stderr)
-}
-
-func isTerminal(f *os.File) bool {
-	return isatty.IsTerminal(f.Fd()) || isatty.IsCygwinTerminal(f.Fd())
-}
-
-// based on https://github.com/watson/ci-info/blob/HEAD/index.js
-func isCI() bool {
-	return os.Getenv("CI") != "" || // GitHub Actions, Travis CI, CircleCI, Cirrus CI, GitLab CI, AppVeyor, CodeShip, dsari
-		os.Getenv("BUILD_NUMBER") != "" || // Jenkins, TeamCity
-		os.Getenv("RUN_ID") != "" // TaskCluster, dsari
 }

--- a/internal/cmd/pgxman/root.go
+++ b/internal/cmd/pgxman/root.go
@@ -10,6 +10,7 @@ import (
 
 	"log/slog"
 
+	"github.com/mattn/go-isatty"
 	"github.com/pgxman/pgxman"
 	"github.com/pgxman/pgxman/internal/auth"
 	"github.com/pgxman/pgxman/internal/log"
@@ -62,7 +63,7 @@ func Execute(ctx context.Context) (*cobra.Command, error) {
 }
 
 func checkUpgrade(ctx context.Context) error {
-	c := upgrade.NewChecker(log.NewTextLogger())
+	c := upgrade.NewChecker(log.NewTextLogger().WithGroup("updater"))
 	result, err := c.Check(ctx)
 	if err != nil {
 		return err
@@ -121,4 +122,23 @@ func newReigstryClient() (registry.Client, error) {
 	}
 
 	return registry.NewClient(flagRegistryURL, t)
+}
+
+func shouldCheckForUpgrade() bool {
+	if os.Getenv("PGXMAN_NO_UPGRADE_NOTIFIER") != "" {
+		return false
+	}
+
+	return pgxman.UpdaterEnabled == "true" && !isCI() && isTerminal(os.Stdout) && isTerminal(os.Stderr)
+}
+
+func isTerminal(f *os.File) bool {
+	return isatty.IsTerminal(f.Fd()) || isatty.IsCygwinTerminal(f.Fd())
+}
+
+// based on https://github.com/watson/ci-info/blob/HEAD/index.js
+func isCI() bool {
+	return os.Getenv("CI") != "" || // GitHub Actions, Travis CI, CircleCI, Cirrus CI, GitLab CI, AppVeyor, CodeShip, dsari
+		os.Getenv("BUILD_NUMBER") != "" || // Jenkins, TeamCity
+		os.Getenv("RUN_ID") != "" // TaskCluster, dsari
 }

--- a/internal/iostreams/iostreams.go
+++ b/internal/iostreams/iostreams.go
@@ -7,13 +7,17 @@ import (
 	"slices"
 
 	"github.com/eiannone/keyboard"
-	"golang.org/x/term"
+	"github.com/mattn/go-isatty"
 )
 
 var (
 	ErrAbortPrompt = fmt.Errorf("abort prompt")
 	ErrNotTerminal = fmt.Errorf("not a terminal")
 )
+
+func IsTerminal(f *os.File) bool {
+	return isatty.IsTerminal(f.Fd()) || isatty.IsCygwinTerminal(f.Fd())
+}
 
 type IOStreams struct {
 	Stdin  io.Reader
@@ -22,7 +26,7 @@ type IOStreams struct {
 }
 
 func (i *IOStreams) IsTerminal() bool {
-	return term.IsTerminal(int(os.Stdout.Fd()))
+	return IsTerminal(os.Stdout)
 }
 
 func (i *IOStreams) Prompt(msg string, continueChars []rune, continueKeys []keyboard.Key) error {

--- a/internal/upgrade/checker.go
+++ b/internal/upgrade/checker.go
@@ -10,9 +10,9 @@ import (
 
 	"github.com/Masterminds/semver/v3"
 	"github.com/google/go-github/v57/github"
-	"github.com/mattn/go-isatty"
 	"github.com/pgxman/pgxman"
 	"github.com/pgxman/pgxman/internal/config"
+	"github.com/pgxman/pgxman/internal/iostreams"
 	"github.com/pgxman/pgxman/internal/log"
 )
 
@@ -129,11 +129,10 @@ func shouldEnable(currentVersion string) bool {
 		return false
 	}
 
-	return pgxman.UpdaterEnabled == "true" && !isCI() && isTerminal(os.Stdout) && isTerminal(os.Stderr)
-}
-
-func isTerminal(f *os.File) bool {
-	return isatty.IsTerminal(f.Fd()) || isatty.IsCygwinTerminal(f.Fd())
+	return pgxman.UpdaterEnabled == "true" &&
+		!isCI() &&
+		iostreams.IsTerminal(os.Stdout) &&
+		iostreams.IsTerminal(os.Stderr)
 }
 
 // based on https://github.com/watson/ci-info/blob/HEAD/index.js

--- a/internal/upgrade/checker_test.go
+++ b/internal/upgrade/checker_test.go
@@ -92,6 +92,7 @@ func Test_Checker(t *testing.T) {
 					assert.WithinDuration(c.LastUpgradeCheckTime, time.Now(), 2*time.Second)
 					return nil
 				},
+				enabled: true,
 			}
 
 			result, err := checker.Check(context.TODO())

--- a/upgrade.go
+++ b/upgrade.go
@@ -1,0 +1,3 @@
+package pgxman
+
+var UpdaterEnabled = ""


### PR DESCRIPTION
Skip the upgrade check in CI. Improve the upgrade checker to report errors only instead of failing the program. This helps with errors like https://github.com/pgxman/pgxman/actions/runs/9036106788/job/24833277155 in CI

This closes https://github.com/Homebrew/brew/issues/17272