### PR TITLE
Remove parallel builds with `--parallel`

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -27,7 +27,6 @@ require (
 	github.com/zcalusic/sysinfo v1.1.0
 	golang.org/x/exp v0.0.0-20231006140011-7918f672742d
 	golang.org/x/oauth2 v0.22.0
-	golang.org/x/sync v0.8.0
 	golang.org/x/text v0.17.0
 	sigs.k8s.io/yaml v1.4.0
 )
@@ -81,6 +80,7 @@ require (
 	github.com/xi2/xz v0.0.0-20171230120015-48954b6210f8 // indirect
 	github.com/xo/terminfo v0.0.0-20220910002029-abceb7e1c41e // indirect
 	golang.org/x/mod v0.17.0 // indirect
+	golang.org/x/sync v0.8.0 // indirect
 	golang.org/x/sys v0.21.0 // indirect
 	golang.org/x/term v0.20.0 // indirect
 	golang.org/x/tools v0.21.1-0.20240508182429-e35e4ccd0d2d // indirect

--- a/internal/cmd/pgxmanpack/root.go
+++ b/internal/cmd/pgxmanpack/root.go
@@ -1,7 +1,6 @@
 package pgxmanpack
 
 import (
-	"fmt"
 	"os"
 	"path/filepath"
 
@@ -15,8 +14,7 @@ import (
 )
 
 var (
-	flagDebug    bool
-	flagParallel int
+	flagDebug bool
 
 	extension    pgxman.Extension
 	packager     pgxman.Packager
@@ -31,10 +29,6 @@ func Execute() error {
 		PersistentPreRunE: func(cmd *cobra.Command, args []string) error {
 			if flagDebug {
 				log.SetLevel(slog.LevelDebug)
-			}
-
-			if flagParallel < 1 {
-				return fmt.Errorf("invalid parallel value: %d", flagParallel)
 			}
 
 			var err error
@@ -54,9 +48,8 @@ func Execute() error {
 			}
 
 			packagerOpts = pgxman.PackagerOptions{
-				WorkDir:  workDir,
-				Parallel: flagParallel,
-				Debug:    flagDebug,
+				WorkDir: workDir,
+				Debug:   flagDebug,
 			}
 
 			return nil
@@ -83,7 +76,6 @@ func Execute() error {
 	}
 
 	root.PersistentFlags().BoolVar(&flagDebug, "debug", os.Getenv("DEBUG") != "", "enable debug logging")
-	root.PersistentFlags().IntVar(&flagParallel, "parallel", 2, "number of parallel builds to run")
 
 	root.AddCommand(newInitCmd())
 	root.AddCommand(newPreCmd())

--- a/packager.go
+++ b/packager.go
@@ -5,9 +5,8 @@ import (
 )
 
 type PackagerOptions struct {
-	WorkDir  string
-	Parallel int
-	Debug    bool
+	WorkDir string
+	Debug   bool
 }
 
 type Packager interface {


### PR DESCRIPTION
Parallel builds don't work for Rust extensions via pgrx. It gets the following errors:

https://github.com/pgxman/buildkit/actions/runs/10356208551/job/28665586672#step:5:1645

In the past, we have set `--parallel 1` in CI anyways so let's remove parallel build until pgrx fixes it.