### PR TITLE
Set `PGRX_HOME` per build for different pg versions

### DIFF
--- a/internal/e2etest/builder_test.go
+++ b/internal/e2etest/builder_test.go
@@ -120,7 +120,7 @@ echo $PGXS
 	builder := pgxman.NewBuilder(
 		pgxman.BuilderOptions{
 			ExtDir:   extdir,
-			Parallel: 1,
+			Parallel: 2,
 			Debug:    flagDebug,
 			// Caching for CI.
 			// They are ignored when not running in GitHub Actions.

--- a/internal/plugin/debian/packager.go
+++ b/internal/plugin/debian/packager.go
@@ -344,6 +344,7 @@ func (p *DebianPackager) buildDebian(ctx context.Context, pkg pgxman.ExtensionPa
 	debuild.Env = append(
 		os.Environ(),
 		fmt.Sprintf("DEB_BUILD_OPTIONS=noautodbgsym parallel=%d", runtime.NumCPU()),
+		fmt.Sprintf("PGRX_HOME=%s", buildDir),
 	)
 	debuild.Dir = buildDir
 	debuild.Stdout = os.Stdout


### PR DESCRIPTION
`pgrx` caches configuration for different pg versions if `PGRX_HOME` is not set. This prevents parallel builds from working.

This is in favor over https://github.com/pgxman/pgxman/pull/216